### PR TITLE
Fix Crane requisites

### DIFF
--- a/crane.nix
+++ b/crane.nix
@@ -97,9 +97,8 @@ let
 
       crate = craneLib.buildPackage (commonArgs // {
         cargoArtifacts = craneLib.buildDepsOnly commonArgs;
-
-        # The resulting executable must be standalone
-        allowedRequisites = [ ];
+      } // lib.optionalAttrs (!stdenv.isDarwin) {
+        allowedRequisites = [];
       });
     in
     crate;


### PR DESCRIPTION
The Nix build is currently broken on my `aarch64-darwin` machine, which CI isn't catching. This PR provides a fix.
