### PR TITLE
Provide non-CI mode

### DIFF
--- a/src/explainers/outdated_deps.md
+++ b/src/explainers/outdated_deps.md
@@ -1,2 +1,0 @@
-<a href="https://github.com/NixOS/nixpkgs">Nixpkgs</a> receives a continuous stream of security patches to keep your software and systems secure.
-Using outdated revisions of Nixpkgs can inadvertently expose you to software security risks that have been resolved in more recent releases.

--- a/src/explainers/supported_refs.md
+++ b/src/explainers/supported_refs.md
@@ -1,3 +1,0 @@
-<a href="https://zero-to-nix.com/concepts/nixos">NixOS</a>'s release branches stop receiving updates roughly 7 months after release and then gradually become more and more insecure over time.
-Non-release branches receive unpredictable updates and should be avoided as dependencies.
-Release branches are also certain to have good <a href="https://zero-to-nix.com/concepts/caching">binary cache</a> coverage, which other branches can't promise.

--- a/src/explainers/upstream_nixpkgs.md
+++ b/src/explainers/upstream_nixpkgs.md
@@ -1,3 +1,0 @@
-We don't recommend using forked or re-exported versions of Nixpkgs.
-While this may be convenient in some cases, it can introduce unexpected behaviors and unwanted security risks.
-While <a href="https://github.com/NixOS/nixpkgs">upstream Nixpkgs</a> isn't bulletproof&mdash;nothing in software is!&mdash;it has a wide range of security measures in place, most notably continuous integration testing with <a href="https://hydra.nixos.org/">Hydra</a>, that mitigate a great deal of supply chain risk.

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -45,10 +45,6 @@ impl Summary {
             // Constants
             "max_days": MAX_DAYS,
             "supported_ref_names": ALLOWED_REFS,
-            // Text snippets
-            "supported_refs_explainer": include_str!("explainers/supported_refs.md"),
-            "outdated_deps_explainer": include_str!("explainers/outdated_deps.md"),
-            "upstream_nixpkgs_explainer": include_str!("explainers/upstream_nixpkgs.md"),
         });
 
         Self { issues, data }

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -13,12 +13,6 @@ pub struct Summary {
 
 impl Summary {
     pub fn new(issues: Vec<Issue>) -> Self {
-        let supported_ref_names = ALLOWED_REFS
-            .iter()
-            .map(|r| format!("* `{r}`"))
-            .collect::<Vec<_>>()
-            .join("\n");
-
         let disallowed: Vec<&Issue> = issues
             .iter()
             .filter(|i| matches!(i.kind, IssueKind::Disallowed))
@@ -50,7 +44,7 @@ impl Summary {
             "non_upstream": non_upstream,
             // Constants
             "max_days": MAX_DAYS,
-            "supported_ref_names": supported_ref_names,
+            "supported_ref_names": ALLOWED_REFS,
             // Text snippets
             "supported_refs_explainer": include_str!("explainers/supported_refs.md"),
             "outdated_deps_explainer": include_str!("explainers/outdated_deps.md"),
@@ -64,7 +58,7 @@ impl Summary {
         let mut handlebars = Handlebars::new();
 
         handlebars
-            .register_template_string("summary.md", include_str!("templates/summary.md"))
+            .register_template_string("summary.md", include_str!("templates/summary_md.hbs"))
             .map_err(Box::new)?;
         let summary_md = handlebars.render("summary.md", &self.data)?;
 
@@ -81,7 +75,7 @@ impl Summary {
     pub fn generate_text(&self) -> Result<(), FlakeCheckerError> {
         let mut handlebars = Handlebars::new();
         handlebars
-            .register_template_string("summary.txt", include_str!("templates/summary.txt"))
+            .register_template_string("summary.txt", include_str!("templates/summary_txt.hbs"))
             .map_err(Box::new)?;
 
         let summary_txt = handlebars.render("summary.txt", &self.data)?;

--- a/src/templates/summary.txt
+++ b/src/templates/summary.txt
@@ -1,1 +1,0 @@
-Number of issues: {{ num_issues }}

--- a/src/templates/summary.txt
+++ b/src/templates/summary.txt
@@ -1,0 +1,1 @@
+Number of issues: {{ num_issues }}

--- a/src/templates/summary_md.hbs
+++ b/src/templates/summary_md.hbs
@@ -32,7 +32,9 @@
 
 <details>
 <summary>Why it's important to use supported branches 📚</summary>
-{{{supported_refs_explainer}}}
+<a href="https://zero-to-nix.com/concepts/nixos">NixOS</a>'s release branches stop receiving updates roughly 7 months after release and then gradually become more and more insecure over time.
+Non-release branches receive unpredictable updates and should be avoided as dependencies.
+Release branches are also certain to have good <a href="https://zero-to-nix.com/concepts/caching">binary cache</a> coverage, which other branches can't promise.
 </details>
 {{/if}}
 
@@ -62,7 +64,8 @@ steps:
 
 <details>
 <summary>Why it's important to keep Nix dependencies up to date 📚</summary>
-{{{outdated_deps_explainer}}}
+<a href="https://github.com/NixOS/nixpkgs">Nixpkgs</a> receives a continuous stream of security patches to keep your software and systems secure.
+Using outdated revisions of Nixpkgs can inadvertently expose you to software security risks that have been resolved in more recent releases.
 </details>
 {{/if}}
 
@@ -90,7 +93,9 @@ per-package <a href="https://ryantm.github.io/nixpkgs/using/overrides">overrides
 
 <details>
 <summary>Why it's important to use upstream Nixpkgs 📚</summary>
-{{{upstream_nixpkgs_explainer}}}
+We don't recommend using forked or re-exported versions of Nixpkgs.
+While this may be convenient in some cases, it can introduce unexpected behaviors and unwanted security risks.
+While <a href="https://github.com/NixOS/nixpkgs">upstream Nixpkgs</a> isn't bulletproof&mdash;nothing in software is!&mdash;it has a wide range of security measures in place, most notably continuous integration testing with <a href="https://hydra.nixos.org/">Hydra</a>, that mitigate a great deal of supply chain risk.
 </details>
 {{/if}}
 {{/if}}

--- a/src/templates/summary_md.hbs
+++ b/src/templates/summary_md.hbs
@@ -4,7 +4,7 @@
 ✅ The Determinate Nix Installer Action scanned your `flake.lock` and didn't identify any problems.
 {{/if}}
 {{#if dirty}}
-⚠️ The Determinate Nix Installer Action scanned your `flake.lock` and discovered a few issues that we recommend looking into.
+⚠️ The Determinate Nix Installer Action scanned your `flake.lock` and discovered {{num_issues}} issues that we recommend looking into.
 
 {{#if has_disallowed}}
 ## Non-supported Git branches for Nixpkgs
@@ -17,7 +17,9 @@
 <summary>What to do 🧰</summary>
 <p>Use one of these branches instead:</p>
 
-{{{supported_ref_names}}}
+{{#each supported_ref_names}}
+* `{{this}}`
+{{/each}}
 
 <p>Here's an example:</p>
 
@@ -60,7 +62,7 @@ steps:
 
 <details>
 <summary>Why it's important to keep Nix dependencies up to date 📚</summary>
-{{{ outdated_deps_explainer }}}
+{{{outdated_deps_explainer}}}
 </details>
 {{/if}}
 
@@ -68,7 +70,7 @@ steps:
 ## Non-upstream Nixpkgs dependencies
 
 {{#each non_upstream}}
-* The `{{this.details.input}}` input has `{{this.details.owner}}` as an owner rather than `NixOS`
+* The `{{this.details.input}}` input has `{{this.details.owner}}` as an owner rather than the `NixOS` org
 {{/each}}
 
 <details>
@@ -88,7 +90,7 @@ per-package <a href="https://ryantm.github.io/nixpkgs/using/overrides">overrides
 
 <details>
 <summary>Why it's important to use upstream Nixpkgs 📚</summary>
-{{{ upstream_nixpkgs_explainer }}}
+{{{upstream_nixpkgs_explainer}}}
 </details>
 {{/if}}
 {{/if}}

--- a/src/templates/summary_txt.hbs
+++ b/src/templates/summary_txt.hbs
@@ -1,0 +1,80 @@
+Flake checker results:
+
+{{#if clean}}
+The flake checker scanned your flake.lock and didn't identify any problems
+{{else}}
+The flake checker scanned your flake.lock and discovered {{num_issues}} issues
+that we recommend looking into:
+
+{{#if has_disallowed}}
+>>> Non-supported Git branches for Nixpkgs
+
+{{#each disallowed}}
+> The {{this.details.input}} input uses the {{this.details.ref}} branch
+{{/each}}
+
+>> What to do
+
+Use one of these branches instead:
+
+{{#each supported_ref_names}}
+* {{this}}
+{{/each}}
+
+>> Why it's important to use supported branches
+
+NixOS's release branches stop receiving updates roughly 7 months after release
+and then gradually become more and more insecure over time. Non-release branches
+receive unpredictable updates and should be avoided as dependencies. Release
+branches are also certain to have good binary cache coverage, which other
+branches can't promise.
+
+{{#if has_outdated}}
+>>> Outdated Nixpkgs dependencies
+
+{{#each outdated}}
+> The {{this.details.input}} input is {{this.details.num_days_old}} days old
+{{/each}}
+
+The maximum recommended age is {{max_days}} days.
+
+>> What to do
+
+For a more automated approach, use the update-flake-lock GitHub Action to create
+create pull requests to update your flake.lock (if you're using Github Actions).
+
+For a more ad hoc approach, use the nix flake update utility.
+
+>> Why it's important to keep Nix dependencies up to date
+
+Nixpkgs receives a continuous stream of security patches to keep your software
+and systems secure. Using outdated revisions of Nixpkgs can inadvertently expose
+you to software security risks that have been resolved in more recent releases.
+{{/if}}
+
+{{#if has_non_upstream}}
+>>> Non-upstream Nixpkgs dependencies
+
+{{#each non_upstream}}
+> The {{this.details.input}} input has {{this.details.owner}} as an owner rather
+  than the NixOS org
+{{/each}}
+`
+>> What to do
+
+Use a Nixpkgs dependency from the NixOS org, such as github:NixOS/nixpkgs.
+
+If you need a customized version of Nixpkgs, we recommend that you use overlays
+and per-package overrides.
+
+>> Why it's important to use upstream Nixpkgs
+
+We don't recommend using forked or re-exported versions of Nixpkgs. While this
+may be convenient in some cases, it can introduce unexpected behaviors and
+unwanted security risks. While upstream Nixpkgs isn't bulletproof (nothing in
+software is!) it has a wide range of security measures in place, most notably
+continuous integration testing with Hydra, that mitigate a great deal of supply
+chain risk.
+{{/if}}
+{{/if}}
+{{/if}}


### PR DESCRIPTION
Here's what non-CI mode currently outputs:

```
Flake checker results:

The flake checker scanned your flake.lock and discovered 3 issues
that we recommend looking into:

>>> Non-supported Git branches for Nixpkgs

> The nixpkgs input uses the this-should-fail branch

>> What to do

Use one of these branches instead:

* nixos-22.11
* nixos-22.11-small
* nixos-23.05
* nixos-23.05-small
* nixos-unstable
* nixos-unstable-small
* nixpkgs-22.11-darwin
* nixpkgs-23.05-darwin
* nixpkgs-unstable

>> Why it's important to use supported branches

NixOS's release branches stop receiving updates roughly 7 months after release
and then gradually become more and more insecure over time. Non-release branches
receive unpredictable updates and should be avoided as dependencies. Release
branches are also certain to have good binary cache coverage, which other
branches can't promise.

>>> Outdated Nixpkgs dependencies

> The nixpkgs input is 55 days old

The maximum recommended age is 30 days.

>> What to do

For a more automated approach, use the update-flake-lock GitHub Action to create
create pull requests to update your flake.lock (if you're using Github Actions).

For a more ad hoc approach, use the nix flake update utility.

>> Why it's important to keep Nix dependencies up to date

Nixpkgs receives a continuous stream of security patches to keep your software
and systems secure. Using outdated revisions of Nixpkgs can inadvertently expose
you to software security risks that have been resolved in more recent releases.

>>> Non-upstream Nixpkgs dependencies

> The nixpkgs input has bitcoin-miner-org as an owner rather
  than the NixOS org
`
>> What to do

Use a Nixpkgs dependency from the NixOS org, such as github:NixOS/nixpkgs.

If you need a customized version of Nixpkgs, we recommend that you use overlays
and per-package overrides.

>> Why it's important to use upstream Nixpkgs

We don't recommend using forked or re-exported versions of Nixpkgs. While this
may be convenient in some cases, it can introduce unexpected behaviors and
unwanted security risks. While upstream Nixpkgs isn't bulletproof (nothing in
software is!) it has a wide range of security measures in place, most notably
continuous integration testing with Hydra, that mitigate a great deal of supply
chain risk.
```

It's definitely intentionally boring but I'm happy to spice it up beyond this if that's the way we want to go.