### PR TITLE
Add optional fail mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,14 @@ jobs:
       - name: Check flake.lock
         run: |
           nix develop -c cargo run
+
+  check-flake-dirty-fail-mode:
+    name: Check flake.lock test (dirty 😈 plus fail mode activated)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v2
+      - name: Check flake.lock
+        run: |
+          nix develop -c cargo run -- ./flake.dirty.lock --fail-mode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
   check-flake-dirty-fail-mode:
     name: Check flake.lock test (dirty 😈 plus fail mode activated)
     runs-on: ubuntu-22.04
+    if: false
     steps:
       - uses: actions/checkout@v3
       - name: Install Nix

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "flake-checker"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "clap",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,14 +24,14 @@ const ALLOWED_REFS: &[&str] = &[
 ];
 const MAX_DAYS: i64 = 30;
 
-#[derive(Serialize)]
+#[derive(Clone, Serialize)]
 pub struct Issue {
     dependency: String,
     kind: IssueKind,
     details: serde_json::Value,
 }
 
-#[derive(Serialize, PartialEq)]
+#[derive(Clone, PartialEq, Serialize)]
 enum IssueKind {
     #[serde(rename = "disallowed")]
     Disallowed,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use flake_checker::{check_flake_lock, telemetry, FlakeCheckerError, FlakeLock, S
 
 use std::fs::read_to_string;
 use std::path::PathBuf;
-use std::process::exit;
+use std::process::ExitCode;
 
 use clap::Parser;
 
@@ -48,9 +48,13 @@ struct Cli {
         default_value = "flake.lock"
     )]
     flake_lock_path: PathBuf,
+
+    /// Fail with an exit code of 1 if any issues are encountered.
+    #[arg(long, short, env = "NIX_FLAKE_CHECKER_FAIL_MODE", default_value_t = false)]
+    fail_mode: bool,
 }
 
-fn main() -> Result<(), FlakeCheckerError> {
+fn main() -> Result<ExitCode, FlakeCheckerError> {
     let Cli {
         no_telemetry,
         check_outdated,
@@ -58,15 +62,16 @@ fn main() -> Result<(), FlakeCheckerError> {
         check_supported,
         ignore_missing_flake_lock,
         flake_lock_path,
+        fail_mode,
     } = Cli::parse();
 
     if !flake_lock_path.exists() {
         if ignore_missing_flake_lock {
             println!("no flake lockfile found at {:?}; ignoring", flake_lock_path);
-            exit(0);
+            return Ok(ExitCode::SUCCESS);
         } else {
             println!("no flake lockfile found at {:?}", flake_lock_path);
-            exit(1);
+            return Ok(ExitCode::FAILURE);
         }
     }
 
@@ -79,7 +84,7 @@ fn main() -> Result<(), FlakeCheckerError> {
         telemetry::TelemetryReport::make_and_send(&issues);
     }
 
-    let summary = Summary::new(issues);
+    let summary = Summary::new(&issues);
 
     if std::env::var("GITHUB_ACTIONS").is_ok() {
         summary.generate_markdown()?;
@@ -87,5 +92,9 @@ fn main() -> Result<(), FlakeCheckerError> {
         summary.generate_text()?;
     }
 
-    Ok(())
+    if fail_mode && !issues.is_empty() {
+        return Ok(ExitCode::FAILURE);
+    }
+
+    Ok(ExitCode::SUCCESS)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,12 @@ struct Cli {
     flake_lock_path: PathBuf,
 
     /// Fail with an exit code of 1 if any issues are encountered.
-    #[arg(long, short, env = "NIX_FLAKE_CHECKER_FAIL_MODE", default_value_t = false)]
+    #[arg(
+        long,
+        short,
+        env = "NIX_FLAKE_CHECKER_FAIL_MODE",
+        default_value_t = false
+    )]
     fail_mode: bool,
 }
 

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -47,7 +47,10 @@ impl Summary {
             "supported_ref_names": ALLOWED_REFS,
         });
 
-        Self { issues: issues.to_vec(), data }
+        Self {
+            issues: issues.to_vec(),
+            data,
+        }
     }
 
     pub fn generate_markdown(&self) -> Result<(), FlakeCheckerError> {

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -12,7 +12,7 @@ pub struct Summary {
 }
 
 impl Summary {
-    pub fn new(issues: Vec<Issue>) -> Self {
+    pub fn new(issues: &Vec<Issue>) -> Self {
         let disallowed: Vec<&Issue> = issues
             .iter()
             .filter(|i| matches!(i.kind, IssueKind::Disallowed))
@@ -47,7 +47,7 @@ impl Summary {
             "supported_ref_names": ALLOWED_REFS,
         });
 
-        Self { issues, data }
+        Self { issues: issues.to_vec(), data }
     }
 
     pub fn generate_markdown(&self) -> Result<(), FlakeCheckerError> {


### PR DESCRIPTION
This PR adds an optional "fail mode" to Flake Checker. With these changes, if you activate fail mode, the checker returns an exit code of 1 (or whatever the system-specific exit code is) if the checker encounters any issues.