### PR TITLE
Bump version to 0.1.3 and update README

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "flake-checker"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flake-checker"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
-# flake-checker
+# Flake Checker
+
+**Flake Checker** is a tool from [Determinate Systems][detsys] that performs "health" checks on the [`flake.lock`][lockfile] files in your [flake][flakes]-powered Nix projects.
+Its goal is to help your Nix projects stay on recent and supported versions of [Nixpkgs].
+
+To run Flake Checker in the root of a Nix project:
 
 ```shell
 nix run github:DeterminateSystems/flake-checker
 
-# Or point to an explicit path
+# Or point to an explicit path for flake.lock
 nix run github:DeterminateSystems/flake-checker /path/to/flake.lock
 ```
 
-Currently performs two checks:
+Flake Checker looks at your `flake.lock`'s root-level [Nixpkgs] inputs and checks that:
 
-- Checks that any explicit Nixpkgs Git refs are in this list:
+- Any explicit Nixpkgs Git refs are in this list:
   - `nixos-22.11`
   - `nixos-22.11-small`
   - `nixos-23.05`
@@ -19,18 +24,36 @@ Currently performs two checks:
   - `nixpkgs-22.11-darwin`
   - `nixpkgs-23.05-darwin`
   - `nixpkgs-unstable`
-- Checks that any Nixpkgs dependencies are less than 30 days old
+- Any Nixpkgs dependencies are less than 30 days old
+- Any Nixpkgs dependencies are have the [`NixOS`][nixos-org] org as the GitHub owner (and thus that the dependency isn't a fork or non-upstream variant)
 
-### Telemetry
+If you're running it locally, Flake Checker reports any issues via text output in your terminal.
+But you can also use Flake Checker [in CI](#the-flake-checker-action).
 
-The goal of the Determinate Flake Checker is to help teams stay on recent and supported versions of Nixpkgs.
+## The Flake Checker Action
+
+You can automate Flake Checker by adding Determinate Systems' [Flake Checker Action][action] to your GitHub Actions workflows:
+
+```yaml
+checks:
+  steps:
+    - uses: actions/checkout@v3
+    - name: Check Nix flake Nixpkgs inputs
+      uses: DeterminateSystems/flake-checker-action@main
+```
+
+When run in GitHub Actions, Flake Checker always exits with a status code of 0&mdash;and thus will never fail your workflows&mdash;and reports its findings as a [Markdown summary][md].
+
+## Telemetry
+
+The goal of Flake Checker is to help teams stay on recent and supported versions of Nixpkgs.
 The flake checker collects a little bit of telemetry information to help us make that true.
 
-Here is a table of the [telemetry data we collect][diagnosticdata]:
+Here is a table of the [telemetry data we collect][telemetry]:
 
 | Field          | Use                                                                                                    |
 | -------------- | ------------------------------------------------------------------------------------------------------ |
-| `distinct_id`  | An opaque string which represents your project, by sha256 hashing repository and organization details. |
+| `distinct_id`  | An opaque string that represents your project, by sha256 hashing repository and organization details.  |
 | `version`      | The version of the Determinate Flake Checker.                                                          |
 | `is_ci`        | Whether the checker is being used in CI (e.g. GitHub Actions).                                         |
 | `disallowed`   | The number of inputs using unsupported branches of Nixpkgs.                                            |
@@ -41,6 +64,12 @@ To disable diagnostic reporting, set the diagnostics URL to an empty string by p
 
 You can read the full privacy policy for [Determinate Systems][detsys], the creators of the Determinate Nix Installer, [here][privacy].
 
-[detsys]: https://determinate.systems/
-[diagnosticdata]: https://github.com/DeterminateSystems/nix-flake-checker/blob/main/src/telemetry.rs#L29-L43
+[action]: https://github.com/DeterminateSystems/flake-checker-action
+[detsys]: https://determinate.systems
+[flakes]: https://zero-to-nix.com/concepts/flakes
+[lockfile]: https://zero-to-nix.com/concepts/flakes#lockfile
+[md]: https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries
+[nixos-org]: https://github.com/NixOS
+[nixpkgs]: https://github.com/NixOS/nixpkgs
 [privacy]: https://determinate.systems/privacy
+[telemetry]: https://github.com/DeterminateSystems/nix-flake-checker/blob/main/src/telemetry.rs#L29-L43

--- a/README.md
+++ b/README.md
@@ -54,19 +54,20 @@ Here is a table of the [telemetry data we collect][telemetry]:
 | Field          | Use                                                                                                    |
 | -------------- | ------------------------------------------------------------------------------------------------------ |
 | `distinct_id`  | An opaque string that represents your project, by sha256 hashing repository and organization details.  |
-| `version`      | The version of the Determinate Flake Checker.                                                          |
-| `is_ci`        | Whether the checker is being used in CI (e.g. GitHub Actions).                                         |
+| `version`      | The version of Flake Checker.                                                                          |
+| `is_ci`        | Whether the checker is being used in CI (GitHub Actions).                                              |
 | `disallowed`   | The number of inputs using unsupported branches of Nixpkgs.                                            |
 | `outdated`     | The number of inputs using outdated versions of Nixpkgs.                                               |
 | `non_upstream` | The number of inputs using forks of Nixpkgs.                                                           |
 
 To disable diagnostic reporting, set the diagnostics URL to an empty string by passing `--no-telemetry` or setting `FLAKE_CHECKER_NO_TELEMETRY=true`.
 
-You can read the full privacy policy for [Determinate Systems][detsys], the creators of the Determinate Nix Installer, [here][privacy].
+You can read the full privacy policy for [Determinate Systems][detsys], the creators of Flake Checker and the [Determinate Nix Installer][installer], [here][privacy].
 
 [action]: https://github.com/DeterminateSystems/flake-checker-action
 [detsys]: https://determinate.systems
 [flakes]: https://zero-to-nix.com/concepts/flakes
+[installer]: https://github.com/DeterminateSystems/nix-installer
 [lockfile]: https://zero-to-nix.com/concepts/flakes#lockfile
 [md]: https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries
 [nixos-org]: https://github.com/NixOS


### PR DESCRIPTION
The addition of "fail mode" in #21 should've come with a patch version bump but I neglected to do that. This PR addresses that and also adds some meat to the README.
