### PR TITLE
Bump version to 0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "flake-checker"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flake-checker"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Since #36 involved user-facing changes, we should bump the version.