### PR TITLE
Allow for explicit Nixpkgs input keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "flake-checker"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flake-checker"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 
 [dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,4 +10,6 @@ pub enum FlakeCheckerError {
     Render(#[from] handlebars::RenderError),
     #[error("handlebars template error: {0}")]
     Template(#[from] Box<handlebars::TemplateError>),
+    #[error("invalid flake.lock: {0}")]
+    Invalid(String),
 }

--- a/src/flake.rs
+++ b/src/flake.rs
@@ -49,6 +49,8 @@ pub fn check_flake_lock(flake_lock: &FlakeLock, config: &FlakeCheckConfig) -> Ve
     let mut issues = vec![];
 
     for (name, dep) in flake_lock.nixpkgs_deps(config.nixpkgs_keys.clone()) {
+        println!("{name}");
+
         if let Node::Repo(repo) = dep {
             // Check if not explicitly supported
             if config.check_supported {
@@ -202,7 +204,7 @@ impl FlakeLock {
         self.nodes
             .iter()
             .filter(|(k, v)| matches!(v, Node::Repo(_)) && keys.contains(k))
-            .map(|(k, v)| (k.clone(), v.clone()))
+            .map(|(k, v)| (String::from(k), v.clone()))
             .collect()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,9 +69,10 @@ struct Cli {
         short,
         env = "NIX_FLAKE_CHECKER_NIXPKGS_KEYS",
         default_value = "nixpkgs",
+        value_delimiter = ',',
         name = "KEY_LIST"
     )]
-    nixpkgs_keys: String,
+    nixpkgs_keys: Vec<String>,
 }
 
 fn main() -> Result<ExitCode, FlakeCheckerError> {
@@ -97,8 +98,6 @@ fn main() -> Result<ExitCode, FlakeCheckerError> {
     }
 
     let flake_lock = FlakeLock::new(&flake_lock_path)?;
-
-    let nixpkgs_keys: Vec<String> = nixpkgs_keys.split(',').map(String::from).collect();
 
     let flake_check_config = FlakeCheckConfig {
         check_supported,

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,16 @@ struct Cli {
         default_value_t = false
     )]
     fail_mode: bool,
+
+    /// Nixpkgs input keys as a comma-separated list.
+    #[arg(
+        long,
+        short,
+        env = "NIX_FLAKE_CHECKER_NIXPKGS_KEYS",
+        default_value = "nixpkgs",
+        name = "KEY_LIST"
+    )]
+    nixpkgs_keys: String,
 }
 
 fn main() -> Result<ExitCode, FlakeCheckerError> {
@@ -73,6 +83,7 @@ fn main() -> Result<ExitCode, FlakeCheckerError> {
         ignore_missing_flake_lock,
         flake_lock_path,
         fail_mode,
+        nixpkgs_keys,
     } = Cli::parse();
 
     if !flake_lock_path.exists() {
@@ -87,10 +98,13 @@ fn main() -> Result<ExitCode, FlakeCheckerError> {
 
     let flake_lock = FlakeLock::new(&flake_lock_path)?;
 
+    let nixpkgs_keys: Vec<String> = nixpkgs_keys.split(',').map(String::from).collect();
+
     let flake_check_config = FlakeCheckConfig {
         check_supported,
         check_outdated,
         check_owner,
+        nixpkgs_keys,
     };
 
     let issues = check_flake_lock(&flake_lock, &flake_check_config);

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ fn main() -> Result<ExitCode, FlakeCheckerError> {
         nixpkgs_keys,
     };
 
-    let issues = check_flake_lock(&flake_lock, &flake_check_config);
+    let issues = check_flake_lock(&flake_lock, &flake_check_config)?;
 
     if !no_telemetry {
         telemetry::TelemetryReport::make_and_send(&issues);

--- a/tests/flake.explicit-keys.0.lock
+++ b/tests/flake.explicit-keys.0.lock
@@ -1,0 +1,171 @@
+{
+  "nodes": {
+    "crane": {
+      "inputs": {
+        "flake-compat": [
+          "flake-compat"
+        ],
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1684468982,
+        "narHash": "sha256-EoC1N5sFdmjuAP3UOkyQujSOT6EdcXTnRw8hPjJkEgc=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "99de890b6ef4b4aab031582125b6056b792a4a30",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1686960236,
+        "narHash": "sha256-AYCC9rXNLpUWzD9hm+askOfpliLEC9kwAo7ITJc4HIw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "04af42f3b31dba0ef742d254456dc4c14eedac86",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-alt": {
+      "locked": {
+        "lastModified": 1686960236,
+        "narHash": "sha256-AYCC9rXNLpUWzD9hm+askOfpliLEC9kwAo7ITJc4HIw=",
+        "owner": "seems-pretty-shady",
+        "repo": "nixpkgs",
+        "rev": "04af42f3b31dba0ef742d254456dc4c14eedac86",
+        "type": "github"
+      },
+      "original": {
+        "owner": "seems-pretty-shady",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-alt": "nixpkgs-alt",
+        "rust-overlay": "rust-overlay_2"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1683080331,
+        "narHash": "sha256-nGDvJ1DAxZIwdn6ww8IFwzoHb2rqBP4wv/65Wt5vflk=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "d59c3fa0cba8336e115b376c2d9e91053aa59e56",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1684808436,
+        "narHash": "sha256-WG5LgB1+Oguj4H4Bpqr5GoLSc382LyGlaToiOw5xhwA=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "a227d4571dd1f948138a40ea8b0d0c413eefb44b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}


### PR DESCRIPTION
This PR enables people to directly specify which input keys should be checked as Nixpkgs inputs:

```shell
flake-checker --nixpkgs-keys nixpkgs,nixpkgs-other,nixpkgs-macos,nixpkgs-alt
```