### PR TITLE
Update Cargo.toml version to 0.1.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "flake-checker"
-version = "0.1.12"
+version = "0.1.14"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flake-checker"
-version = "0.1.12"
+version = "0.1.14"
 edition = "2021"
 
 [workspace]


### PR DESCRIPTION
In what amounts to a pretty glaring oversight, the `Cargo.toml` version was updated for neither 0.1.13 nor 0.1.14. This PR fixes that.
