### PR TITLE
Automatically pull request changes to allowed refs list

### DIFF
--- a/.github/workflows/allowed-refs.yaml
+++ b/.github/workflows/allowed-refs.yaml
@@ -17,3 +17,20 @@ jobs:
       - name: Check allowed refs
         run: |
           nix develop --command cargo run --features allowed-refs -- --check-allowed-refs
+
+      - name: Update allowed-refs.json
+        if: failure()
+        run: |
+          allowed_refs_json=$(nix develop --command cargo run --features allowed-refs -- --get-allowed-refs | jq .)
+          echo "${allowed_refs_json}" > allowed-refs.json
+
+      - name: Create pull request
+        if: failure()
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: Update allowed-refs.json to new valid Git refs list
+          title: Update allowed-refs.json
+          body: |
+            Nixpkgs has changed its list of maintained references. This PR updates `allowed-refs.json` to reflect that change.
+          branch: updated-allowed-refs
+          base: main

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,7 @@ dependencies = [
  "clap",
  "handlebars",
  "is_ci",
+ "once_cell",
  "parse-flake-lock",
  "reqwest",
  "serde",
@@ -613,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl-probe"
@@ -697,18 +698,18 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -879,18 +880,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -899,9 +900,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",
@@ -968,9 +969,9 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,11 @@ chrono = { version = "0.4.25", default-features = false, features = [ "clock" ] 
 clap = { version = "4.3.0", default-features = false, features = [ "derive", "env", "std", "wrap_help" ] }
 handlebars = { version = "4.3.7", default-features = false }
 is_ci = "1.1.1"
+once_cell = { version = "1.19.0", default-features = false }
 parse-flake-lock = { path = "./parse-flake-lock" }
 reqwest = { version = "0.11.18", default-features = false, features = ["blocking", "json", "rustls-tls-native-roots"] }
 serde = { version = "1.0.163", features = [ "derive" ] }
-serde_json = { version = "1.0.96", default-features = false }
+serde_json = { version = "1.0.116", default-features = false, features = ["std"] }
 sha2 = { version = "0.10.6", default-features = false }
 thiserror = "1.0.40"
 

--- a/allowed-refs.json
+++ b/allowed-refs.json
@@ -1,0 +1,8 @@
+[
+  "nixos-23.11",
+  "nixos-23.11-small",
+  "nixos-unstable",
+  "nixos-unstable-small",
+  "nixpkgs-23.11-darwin",
+  "nixpkgs-unstable"
+]

--- a/src/allowed_refs.rs
+++ b/src/allowed_refs.rs
@@ -1,4 +1,4 @@
-use crate::{error::FlakeCheckerError, flake::ALLOWED_REFS};
+use crate::error::FlakeCheckerError;
 
 use serde::Deserialize;
 
@@ -26,8 +26,8 @@ struct Metric {
     current: String,
 }
 
-pub(crate) fn check() -> Result<bool, FlakeCheckerError> {
-    Ok(get()? == ALLOWED_REFS)
+pub(crate) fn check(allowed_refs: Vec<String>) -> Result<bool, FlakeCheckerError> {
+    Ok(get()? == allowed_refs)
 }
 
 pub(crate) fn get() -> Result<Vec<String>, FlakeCheckerError> {

--- a/src/flake.rs
+++ b/src/flake.rs
@@ -8,18 +8,6 @@ use crate::FlakeCheckerError;
 use chrono::{Duration, Utc};
 use parse_flake_lock::{FlakeLock, Node};
 
-// Update this when necessary by running `get-allowed-refs` to fetch
-// the current values from monitoring.nixos.org. There's also an automated
-// check in .github/workflows/allowed-refs.yaml that checks once a day to
-// ensure that this remains in sync.
-pub const ALLOWED_REFS: &[&str] = &[
-    "nixos-23.11",
-    "nixos-23.11-small",
-    "nixos-unstable",
-    "nixos-unstable-small",
-    "nixpkgs-23.11-darwin",
-    "nixpkgs-unstable",
-];
 pub const MAX_DAYS: i64 = 30;
 
 pub(crate) struct FlakeCheckConfig {
@@ -91,6 +79,7 @@ fn nixpkgs_deps(
 pub(crate) fn check_flake_lock(
     flake_lock: &FlakeLock,
     config: &FlakeCheckConfig,
+    allowed_refs: Vec<String>,
 ) -> Result<Vec<Issue>, FlakeCheckerError> {
     let mut issues = vec![];
 
@@ -101,7 +90,7 @@ pub(crate) fn check_flake_lock(
             // Check if not explicitly supported
             if config.check_supported {
                 if let Some(ref git_ref) = repo.original.git_ref {
-                    if !ALLOWED_REFS.contains(&git_ref.as_str()) {
+                    if !allowed_refs.contains(&git_ref) {
                         issues.push(Issue {
                             input: name.clone(),
                             kind: IssueKind::Disallowed(Disallowed {

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,7 +120,8 @@ fn main() -> Result<ExitCode, FlakeCheckerError> {
     if get_allowed_refs {
         match allowed_refs::get() {
             Ok(refs) => {
-                println!("{}", refs.join("\n"));
+                let json_refs = serde_json::to_string(&refs)?;
+                println!("{json_refs}");
                 return Ok(ExitCode::SUCCESS);
             }
             Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,6 +98,9 @@ struct Cli {
 }
 
 fn main() -> Result<ExitCode, FlakeCheckerError> {
+    let allowed_refs: Vec<String> = serde_json::from_str(include_str!("../allowed-refs.json"))
+        .expect("couldn't deserialize allowed-refs.json file");
+
     let Cli {
         no_telemetry,
         check_outdated,
@@ -166,13 +169,13 @@ fn main() -> Result<ExitCode, FlakeCheckerError> {
         fail_mode,
     };
 
-    let issues = check_flake_lock(&flake_lock, &flake_check_config)?;
+    let issues = check_flake_lock(&flake_lock, &flake_check_config, allowed_refs.clone())?;
 
     if !no_telemetry {
         telemetry::TelemetryReport::make_and_send(&issues);
     }
 
-    let summary = Summary::new(&issues, flake_lock_path, flake_check_config);
+    let summary = Summary::new(&issues, flake_lock_path, flake_check_config, allowed_refs);
 
     if std::env::var("GITHUB_ACTIONS").is_ok() {
         if markdown_summary {

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,7 +132,7 @@ fn main() -> Result<ExitCode, FlakeCheckerError> {
 
     #[cfg(feature = "allowed-refs")]
     if check_allowed_refs {
-        match allowed_refs::check() {
+        match allowed_refs::check(allowed_refs) {
             Ok(equals) => {
                 if equals {
                     println!("The allowed reference sets are up to date.");

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -1,5 +1,5 @@
 use crate::error::FlakeCheckerError;
-use crate::flake::{ALLOWED_REFS, MAX_DAYS};
+use crate::flake::MAX_DAYS;
 use crate::issue::{Issue, IssueKind};
 use crate::FlakeCheckConfig;
 
@@ -32,6 +32,7 @@ impl Summary {
         issues: &Vec<Issue>,
         flake_lock_path: PathBuf,
         flake_check_config: FlakeCheckConfig,
+        allowed_refs: Vec<String>,
     ) -> Self {
         let disallowed: Vec<&Issue> = issues.iter().filter(|i| i.kind.is_disallowed()).collect();
         let outdated: Vec<&Issue> = issues.iter().filter(|i| i.kind.is_outdated()).collect();
@@ -55,7 +56,7 @@ impl Summary {
             "non_upstream": non_upstream,
             // Constants
             "max_days": MAX_DAYS,
-            "supported_ref_names": ALLOWED_REFS,
+            "supported_ref_names": allowed_refs,
         });
 
         Self {


### PR DESCRIPTION
At the moment, if the allowed refs list changes in Nixpkgs, a daily cron-jobbed Action fails and sends us a notification. With the changes in this PR, the allowed refs list is no longer hard-coded but rather stored in a JSON file and the allowed refs Action now automatically PRs the correct list to this repo.