### PR TITLE
Fix artifact name in build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
             artifact: flake-checker-X64-Linux
           - nix-system: x86_64-linux
             runner: ubuntu-22.04
-            artifact: flake-checker-ARM64-linux
+            artifact: flake-checker-ARM64-Linux
     steps:
       - name: git checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This is breaking the release workflow because it can't find the proper binary stored in the cache.
