### PR TITLE
Stop unnecessary per-PR builds

### DIFF
--- a/.github/workflows/release-prs.yaml
+++ b/.github/workflows/release-prs.yaml
@@ -10,12 +10,7 @@ on:
 
 jobs:
   build:
-    uses: ./.github/workflows/build.yaml
-
-  release:
-    needs: build
-
-    concurrency: release
+    # We want to build and upload artifacts only if the `upload to s3` label is applied
     # Only intra-repo PRs are allowed to have PR artifacts uploaded
     # We only want to trigger once the upload once in the case the upload label is added, not when any label is added
     if: |
@@ -24,6 +19,11 @@ jobs:
           (github.event.action == 'labeled' && github.event.label.name == 'upload to s3')
           || (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'upload to s3'))
         )
+    uses: ./.github/workflows/build.yaml
+
+  release:
+    needs: build
+    concurrency: release
     runs-on: ubuntu-latest
     permissions:
       id-token: write # In order to request a JWT for AWS auth


### PR DESCRIPTION
Right now, we're building artifacts as part of the `Release PR` workflow even when those artifacts aren't being uploaded (because the `upload to s3` label isn't being applied). This moves the `if` statement up to the `build` job to keep that from happening.