### PR TITLE
Update channel revisions URL

### DIFF
--- a/src/allowed_refs.rs
+++ b/src/allowed_refs.rs
@@ -2,8 +2,7 @@ use crate::error::FlakeCheckerError;
 
 use serde::Deserialize;
 
-const ALLOWED_REFS_URL: &str =
-    "https://monitoring.nixos.org/prometheus/api/v1/query?query=channel_revision";
+const ALLOWED_REFS_URL: &str = "https://prometheus.nixos.org/api/v1/query?query=channel_revision";
 
 #[derive(Deserialize)]
 struct Response {


### PR DESCRIPTION
The original URL now redirects to this. We might as well update it in place here.

```shell
curl -I "https://monitoring.nixos.org/prometheus/api/v1/query?query=channel_revision"
```

```http
HTTP/2 301
server: nginx
date: Sun, 02 Jun 2024 16:30:03 GMT
content-type: text/html
content-length: 162
location: https://prometheus.nixos.org/api/v1/query?query=channel_revision
access-control-allow-origin: *
```
