### PR TITLE
Sort refs list in allowed-refs.json

### DIFF
--- a/allowed-refs.json
+++ b/allowed-refs.json
@@ -1,8 +1,8 @@
 [
-  "nixpkgs-24.05-darwin",
   "nixos-24.05",
-  "nixpkgs-unstable",
   "nixos-24.05-small",
+  "nixos-unstable",
   "nixos-unstable-small",
-  "nixos-unstable"
+  "nixpkgs-24.05-darwin",
+  "nixpkgs-unstable"
 ]

--- a/flake.lock
+++ b/flake.lock
@@ -21,12 +21,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1726838390,
-        "narHash": "sha256-NmcVhGElxDbmEWzgXsyAjlRhUus/nEqPC5So7BOJLUM=",
-        "rev": "944b2aea7f0a2d7c79f72468106bc5510cbf5101",
-        "revCount": 635367,
+        "lastModified": 1729307008,
+        "narHash": "sha256-QUvb6epgKi9pCu9CttRQW4y5NqJ+snKr1FZpG/x3Wtc=",
+        "rev": "a9b86fc2290b69375c5542b622088eb6eca2a7c3",
+        "revCount": 636009,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2405.635367%2Brev-944b2aea7f0a2d7c79f72468106bc5510cbf5101/019213de-4759-79c6-b638-0878c1fd0179/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2405.636009%2Brev-a9b86fc2290b69375c5542b622088eb6eca2a7c3/0192adf6-8ea6-72ef-aeee-39631619cc73/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719800573,
-        "narHash": "sha256-9DLgG4T6l7cc4pJNOCcXGUwHsFfUp8KLsiwed65MdHk=",
+        "lastModified": 1729477859,
+        "narHash": "sha256-r0VyeJxy4O4CgTB/PNtfQft9fPfN1VuGvnZiCxDArvg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "648b25dd9c3acd255dc50c1eb3ca8b987856f675",
+        "rev": "ada8266712449c4c0e6ee6fcbc442b3c217c79e1",
         "type": "github"
       },
       "original": {

--- a/src/allowed_refs.rs
+++ b/src/allowed_refs.rs
@@ -30,7 +30,7 @@ pub(crate) fn check(allowed_refs: Vec<String>) -> Result<bool, FlakeCheckerError
 }
 
 pub(crate) fn get() -> Result<Vec<String>, FlakeCheckerError> {
-    let officially_supported: Vec<String> = reqwest::blocking::get(ALLOWED_REFS_URL)?
+    let mut officially_supported: Vec<String> = reqwest::blocking::get(ALLOWED_REFS_URL)?
         .json::<Response>()?
         .data
         .result
@@ -38,6 +38,8 @@ pub(crate) fn get() -> Result<Vec<String>, FlakeCheckerError> {
         .filter(|res| res.metric.current == "1")
         .map(|res| res.metric.channel.clone())
         .collect();
+
+    officially_supported.sort();
 
     Ok(officially_supported)
 }

--- a/src/allowed_refs.rs
+++ b/src/allowed_refs.rs
@@ -25,11 +25,11 @@ struct Metric {
     current: String,
 }
 
-pub(crate) fn check(allowed_refs: Vec<String>) -> Result<bool, FlakeCheckerError> {
-    Ok(get()? == allowed_refs)
+pub(crate) fn check_allowed_refs(allowed_refs: Vec<String>) -> Result<bool, FlakeCheckerError> {
+    Ok(fetch_allowed_refs()? == allowed_refs)
 }
 
-pub(crate) fn get() -> Result<Vec<String>, FlakeCheckerError> {
+pub(crate) fn fetch_allowed_refs() -> Result<Vec<String>, FlakeCheckerError> {
     let mut officially_supported: Vec<String> = reqwest::blocking::get(ALLOWED_REFS_URL)?
         .json::<Response>()?
         .data

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,7 +192,7 @@ fn main() -> Result<ExitCode, FlakeCheckerError> {
     }
 
     if get_allowed_refs {
-        match allowed_refs::get() {
+        match allowed_refs::fetch_allowed_refs() {
             Ok(refs) => {
                 let json_refs = serde_json::to_string(&refs)?;
                 println!("{json_refs}");
@@ -206,10 +206,12 @@ fn main() -> Result<ExitCode, FlakeCheckerError> {
     }
 
     if check_allowed_refs {
-        let allowed_refs: Vec<String> =
+        let mut allowed_refs: Vec<String> =
             serde_json::from_str(include_str!("../allowed-refs.json")).unwrap();
 
-        match allowed_refs::check(allowed_refs) {
+        allowed_refs.sort();
+
+        match allowed_refs::check_allowed_refs(allowed_refs) {
             Ok(equals) => {
                 if equals {
                     println!("The allowed reference sets are up to date.");


### PR DESCRIPTION
The automatic update in #138 indicates that the allowed refs check can fail if the ordering of the fetched array doesn't match the local `allowed-refs.json`, which is a bug. This PR fixes that by sorting the array before writing it to disk.