### PR TITLE
Make `narHash` field optional for locked inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,7 +519,7 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flake-checker"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "cel-interpreter",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flake-checker"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 
 [workspace]

--- a/parse-flake-lock/src/lib.rs
+++ b/parse-flake-lock/src/lib.rs
@@ -269,7 +269,7 @@ pub struct RepoLocked {
     pub last_modified: i64,
     /// The NAR hash of the input.
     #[serde(alias = "narHash")]
-    pub nar_hash: String,
+    pub nar_hash: Option<String>,
     /// The repository owner.
     pub owner: String,
     /// The repository.
@@ -340,7 +340,7 @@ pub struct PathLocked {
     pub last_modified: i64,
     /// The NAR hash of the input.
     #[serde(alias = "narHash")]
-    pub nar_hash: String,
+    pub nar_hash: Option<String>,
     /// The relative filesystem path for the input.
     pub path: PathBuf,
     /// The type of the node (always `"path"`).
@@ -380,7 +380,7 @@ pub struct TarballLocked {
     pub last_modified: Option<i64>,
     /// The NAR hash of the input.
     #[serde(alias = "narHash")]
-    pub nar_hash: String,
+    pub nar_hash: Option<String>,
     /// The type of the node (always `"tarball"`).
     #[serde(alias = "type")]
     pub node_type: String,


### PR DESCRIPTION
With the introduction of lazy trees, the `narHash` field will no longer be present for most locked inputs.
