### PR TITLE
Use standard Nixpkgs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.aarch64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
-[target.x86_64-unknown-linux-musl]
-rustflags = ["-C", "target-feature=+crt-static"]
-
-[target.aarch64-unknown-linux-musl]
-rustflags = ["-C", "target-feature=+crt-static"]
+[target.'cfg(target_os = "linux")']
+rustflags = [
+  "--cfg", "tokio_unstable",
+  "-Crelocation-model=static",
+]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
             system: X64-Linux
     steps:
       - name: git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Determinate Nix
         uses: DeterminateSystems/determinate-nix-action@main

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,6 +43,11 @@ jobs:
           nix build -L ".#packages.${{ matrix.systems.nix-system }}.default"
           cp ./result/bin/flake-checker flake-checker
 
+      - name: Ensure that flake-checker binary is static on Linux
+        if: contains(matrix.systems.nix-system, 'linux')
+        run: |
+          ldd ./flake-checker && echo "❌👎 DYNAMIC" && exit 1 || echo "✅👍 STATIC"
+
       - name: Upload flake-checker executable for ${{ matrix.systems.system }}
         uses: actions/upload-artifact@v4.3.3
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,12 @@ jobs:
       - name: Ensure that flake-checker binary is static on Linux
         if: contains(matrix.systems.nix-system, 'linux')
         run: |
-          ldd ./flake-checker && echo "❌👎 DYNAMIC" && exit 1 || echo "✅👍 STATIC"
+          if file ./flake-checker | grep -E -q "static.+linked"; then
+            echo "✅👍 STATIC"
+          else
+            echo "❌👎 DYNAMIC"
+            exit 1
+          fi
 
       - name: Upload flake-checker executable for ${{ matrix.systems.system }}
         uses: actions/upload-artifact@v4.3.3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: DeterminateSystems/determinate-nix-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
       - name: Check flake.lock
@@ -34,7 +34,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: DeterminateSystems/determinate-nix-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
       - name: cargo test
@@ -47,7 +47,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: DeterminateSystems/determinate-nix-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
       - name: Check flake.lock
@@ -64,7 +64,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: DeterminateSystems/determinate-nix-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
       - name: Check flake.lock
@@ -78,7 +78,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: DeterminateSystems/determinate-nix-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
       - name: Check flake.lock
@@ -93,7 +93,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: DeterminateSystems/determinate-nix-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
       - name: Check flake.lock
@@ -125,7 +125,10 @@ jobs:
           - system: ARM64-macOS
             runner: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
+      - name: Install Determinate Nix
+        uses: DeterminateSystems/determinate-nix-action@main
 
       - name: Download flake-checker for ${{ matrix.systems.system }}
         uses: actions/download-artifact@v4.1.7

--- a/.github/workflows/flakehub-publish-tagged.yaml
+++ b/.github/workflows/flakehub-publish-tagged.yaml
@@ -18,7 +18,7 @@ jobs:
       id-token: "write"
       contents: "read"
     steps:
-      - uses: "actions/checkout@v4"
+      - uses: "actions/checkout@v6"
         with:
           ref: "${{ (inputs.tag != null) && format('refs/tags/{0}', inputs.tag) || '' }}"
       - uses: "DeterminateSystems/determinate-nix-action@main"

--- a/.github/workflows/ref-statuses.yaml
+++ b/.github/workflows/ref-statuses.yaml
@@ -12,7 +12,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: DeterminateSystems/determinate-nix-action@main
 

--- a/.github/workflows/release-branches.yaml
+++ b/.github/workflows/release-branches.yaml
@@ -21,7 +21,7 @@ jobs:
       id-token: write # In order to request a JWT for AWS auth
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create the artifacts directory
         run: rm -rf ./artifacts && mkdir ./artifacts

--- a/.github/workflows/release-prs.yaml
+++ b/.github/workflows/release-prs.yaml
@@ -30,7 +30,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create the artifacts directory
         run: rm -rf ./artifacts && mkdir ./artifacts

--- a/.github/workflows/release-tags.yaml
+++ b/.github/workflows/release-tags.yaml
@@ -19,7 +19,7 @@ jobs:
       id-token: write # In order to request a JWT for AWS auth
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create the artifacts directory
         run: rm -rf ./artifacts && mkdir ./artifacts

--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -3,7 +3,7 @@ name: update-flake-lock
 on:
   workflow_dispatch: # enable manual triggering
   schedule:
-    - cron: '0 0 */15 * *' # every 15th day of the month
+    - cron: "0 0 */15 * *" # every 15th day of the month
 
 jobs:
   lockfile:
@@ -12,7 +12,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: DeterminateSystems/determinate-nix-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
       - uses: DeterminateSystems/update-flake-lock@main

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,10 +78,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "base64"
-version = "0.21.7"
+name = "aws-lc-rs"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "base64"
@@ -103,12 +119,6 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -173,6 +183,12 @@ dependencies = [
  "lalrpop-util",
  "regex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -240,6 +256,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,16 +290,6 @@ name = "compression-core"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "core-foundation"
@@ -353,7 +378,7 @@ dependencies = [
  "chrono",
  "detsys-srv",
  "hickory-resolver",
- "http 1.4.0",
+ "http",
  "iana-time-zone",
  "is_ci",
  "reqwest 0.12.24",
@@ -381,7 +406,7 @@ dependencies = [
  "async-trait",
  "futures-util",
  "hickory-resolver",
- "http 1.4.0",
+ "http",
  "rand",
  "thiserror 2.0.17",
  "tracing",
@@ -437,6 +462,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,15 +480,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
 dependencies = [
  "log",
-]
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -516,7 +538,7 @@ dependencies = [
  "detsys-ids-client",
  "handlebars",
  "parse-flake-lock",
- "reqwest 0.11.27",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -524,12 +546,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -541,12 +557,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -593,6 +616,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -635,25 +659,6 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -736,17 +741,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -757,23 +751,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http",
 ]
 
 [[package]]
@@ -784,8 +767,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -794,36 +777,6 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
 
 [[package]]
 name = "hyper"
@@ -835,8 +788,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -848,32 +801,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.4.0",
- "hyper 1.8.1",
+ "http",
+ "hyper",
  "hyper-util",
- "rustls 0.23.35",
- "rustls-native-certs 0.8.2",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -883,14 +822,14 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.8.1",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -1098,6 +1037,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,7 +1149,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "libc",
 ]
 
@@ -1217,12 +1200,6 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -1308,7 +1285,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -1512,7 +1489,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.35",
+ "rustls",
  "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
@@ -1526,13 +1503,14 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
  "rand",
  "ring",
  "rustc-hash",
- "rustls 0.23.35",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.17",
@@ -1605,7 +1583,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -1656,77 +1634,75 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration",
- "tokio",
- "tokio-rustls 0.24.1",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
  "async-compression",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.35",
- "rustls-native-certs 0.8.2",
+ "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -1777,7 +1753,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1786,40 +1762,17 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.8",
+ "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "schannel",
- "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -1831,16 +1784,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.5.1",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
+ "security-framework",
 ]
 
 [[package]]
@@ -1854,14 +1798,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.101.7"
+name = "rustls-platform-verifier"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
- "ring",
- "untrusted",
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -1869,6 +1830,7 @@ version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1887,6 +1849,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1902,36 +1873,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.10.0",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
 name = "security-framework"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags 2.10.0",
- "core-foundation 0.10.1",
+ "bitflags",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2118,12 +2066,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -2163,27 +2105,6 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-io-kit",
  "windows",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -2346,21 +2267,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.35",
+ "rustls",
  "tokio",
 ]
 
@@ -2386,7 +2297,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -2394,15 +2305,15 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -2562,6 +2473,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2664,6 +2585,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2684,6 +2614,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -2832,6 +2771,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -2864,6 +2812,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -2925,6 +2888,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -2943,6 +2912,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -2958,6 +2933,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2991,6 +2972,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -3006,6 +2993,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3027,6 +3020,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -3042,6 +3041,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,9 +133,9 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ clap = { version = "4.3.0", default-features = false, features = [
 detsys-ids-client = { version = "0.6", features = ["tracing-instrument"] }
 handlebars = { version = "4.3.7", default-features = false }
 parse-flake-lock = { path = "./parse-flake-lock" }
-reqwest = { version = "0.11.18", default-features = false, features = [
+reqwest = { version = "0.13", default-features = false, features = [
   "blocking",
   "json",
-  "rustls-tls-native-roots",
+  "rustls",
 ] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ You can automate Nix Flake Checker by adding Determinate Systems' [Nix Flake Che
 ```yaml
 checks:
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Check Nix flake Nixpkgs inputs
       uses: DeterminateSystems/flake-checker-action@main
 ```
@@ -162,4 +162,3 @@ If you'd like to help make the parser more exhaustive, [pull requests][prs] are 
 [rust]: https://rust-lang.org
 [telemetry]: https://github.com/DeterminateSystems/nix-flake-checker/blob/main/src/telemetry.rs#L29-L43
 [val]: https://docs.rs/serde_json/latest/serde_json/value/enum.Value.html
-

--- a/flake.lock
+++ b/flake.lock
@@ -120,16 +120,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1766423894,
-        "narHash": "sha256-8uUHYKMfzu6qgF9M0VYJ3Fw4HJWmJiNRToGBojE5wEU=",
-        "rev": "91461f7fe3c87a3f1d631608943519b0456e0e2e",
-        "revCount": 313,
+        "lastModified": 1774106199,
+        "narHash": "sha256-US5Tda2sKmjrg2lNHQL3jRQ6p96cgfWh3J1QBliQ8Ws=",
+        "rev": "6c9a78c09ff4d6c21d0319114873508a6ec01655",
+        "revCount": 967235,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/secure/0.904649.313/019b4714-003c-7b50-a3aa-ffc368440845/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.967235%2Brev-6c9a78c09ff4d6c21d0319114873508a6ec01655/019d198c-70dc-7753-b1d1-721451f578ae/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/DeterminateSystems/secure/0"
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1"
       }
     },
     "root": {

--- a/flake.lock
+++ b/flake.lock
@@ -11,12 +11,26 @@
       },
       "original": {
         "type": "tarball",
+        "url": "https://flakehub.com/f/ipetkov/crane/0.20.3"
+      }
+    },
+    "crane_2": {
+      "locked": {
+        "lastModified": 1745454774,
+        "narHash": "sha256-oLvmxOnsEKGtwczxp/CwhrfmQUG2ym24OMWowcoRhH8=",
+        "rev": "efd36682371678e2b6da3f108fdb5c613b3ec598",
+        "revCount": 729,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/ipetkov/crane/0.20.3/01966538-0f80-7363-a573-2ba9fd154399/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
         "url": "https://flakehub.com/f/ipetkov/crane/0"
       }
     },
     "easy-template": {
       "inputs": {
-        "crane": "crane",
+        "crane": "crane_2",
         "fenix": "fenix",
         "nixpkgs": [
           "nixpkgs"
@@ -76,48 +90,6 @@
         "url": "https://flakehub.com/f/nix-community/fenix/0"
       }
     },
-    "fenix_3": {
-      "inputs": {
-        "nixpkgs": [
-          "naersk",
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src_3"
-      },
-      "locked": {
-        "lastModified": 1752475459,
-        "narHash": "sha256-z6QEu4ZFuHiqdOPbYss4/Q8B0BFhacR8ts6jO/F/aOU=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "bf0d6f70f4c9a9cf8845f992105652173f4b617f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
-        "type": "github"
-      }
-    },
-    "naersk": {
-      "inputs": {
-        "fenix": "fenix_3",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1763384566,
-        "narHash": "sha256-r+wgI+WvNaSdxQmqaM58lVNvJYJ16zoq+tKN20cLst4=",
-        "rev": "d4155d6ebb70fbe2314959842f744aa7cabbbf6a",
-        "revCount": 381,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/nix-community/naersk/0.1.381%2Brev-d4155d6ebb70fbe2314959842f744aa7cabbbf6a/019b3a44-9ce1-7d8e-9d0c-f07a28444fd1/source.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/nix-community/naersk/0"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1774106199,
@@ -134,9 +106,9 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "easy-template": "easy-template",
         "fenix": "fenix_2",
-        "naersk": "naersk",
         "nixpkgs": "nixpkgs"
       }
     },
@@ -165,23 +137,6 @@
         "owner": "rust-lang",
         "repo": "rust-analyzer",
         "rev": "a9026e6d5068172bf5a0d52a260bb290961d1cb4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
-      }
-    },
-    "rust-analyzer-src_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1752428706,
-        "narHash": "sha256-EJcdxw3aXfP8Ex1Nm3s0awyH9egQvB2Gu+QEnJn2Sfg=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "591e3b7624be97e4443ea7b5542c191311aa141d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1745454774,
-        "narHash": "sha256-oLvmxOnsEKGtwczxp/CwhrfmQUG2ym24OMWowcoRhH8=",
-        "rev": "efd36682371678e2b6da3f108fdb5c613b3ec598",
-        "revCount": 729,
+        "lastModified": 1774313390,
+        "narHash": "sha256-BEp040fMklOW2+ttpNUKivlE0hzpv0AAP+0kG47uVCk=",
+        "rev": "ca870b74b19e5433c4171e84ebf359aaef7b3e7e",
+        "revCount": 830,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/ipetkov/crane/0.20.3/01966538-0f80-7363-a573-2ba9fd154399/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/ipetkov/crane/0.23.2/019d1d54-2086-73ce-8807-3163b406a5cd/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/ipetkov/crane/0.20.3"
+        "url": "https://flakehub.com/f/ipetkov/crane/0"
       }
     },
     "crane_2": {
@@ -70,6 +70,26 @@
         "url": "https://flakehub.com/f/nix-community/fenix/0.1"
       }
     },
+    "fenix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src_2"
+      },
+      "locked": {
+        "lastModified": 1772348640,
+        "narHash": "sha256-caiKs7O4khFydpKyg8O8/nmvw/NfN4fn/4spageGoig=",
+        "rev": "47c5355eaba0b08836e720d5d545c8ea1e1783db",
+        "revCount": 2572,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/nix-community/fenix/0.1.2572%2Brev-47c5355eaba0b08836e720d5d545c8ea1e1783db/019ca881-cb35-7cd1-8b46-98117609f8b6/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/nix-community/fenix/0.1"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1774106199,
@@ -88,6 +108,7 @@
       "inputs": {
         "crane": "crane",
         "easy-template": "easy-template",
+        "fenix": "fenix_2",
         "nixpkgs": "nixpkgs"
       }
     },
@@ -99,6 +120,23 @@
         "owner": "rust-lang",
         "repo": "rust-analyzer",
         "rev": "fe8444616679f8e50ff9696f4750df1f10e7433d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "rust-analyzer-src_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772310333,
+        "narHash": "sha256-njFwHnxYcfQINwSa+XWhenv8s8PMg/j5ID0HpIa49xM=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "a96b6a9b887008bae01839543f9ca8e1f67f4ebe",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -70,26 +70,6 @@
         "url": "https://flakehub.com/f/nix-community/fenix/0.1"
       }
     },
-    "fenix_2": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src_2"
-      },
-      "locked": {
-        "lastModified": 1767250179,
-        "narHash": "sha256-PnQdWvPZqHp+7yaHWDFX3NYSKaOy0fjkwpR+rIQC7AY=",
-        "rev": "a3eaf682db8800962943a77ab77c0aae966f9825",
-        "revCount": 2511,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/nix-community/fenix/0.1.2511%2Brev-a3eaf682db8800962943a77ab77c0aae966f9825/019b78a8-f9ad-7faf-9a11-350b6ae3fcd9/source.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/nix-community/fenix/0"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1774106199,
@@ -108,7 +88,6 @@
       "inputs": {
         "crane": "crane",
         "easy-template": "easy-template",
-        "fenix": "fenix_2",
         "nixpkgs": "nixpkgs"
       }
     },
@@ -120,23 +99,6 @@
         "owner": "rust-lang",
         "repo": "rust-analyzer",
         "rev": "fe8444616679f8e50ff9696f4750df1f10e7433d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
-      }
-    },
-    "rust-analyzer-src_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1767191410,
-        "narHash": "sha256-cCZGjubgDWmstvFkS6eAw2qk2ihgWkycw55u2dtLd70=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "a9026e6d5068172bf5a0d52a260bb290961d1cb4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -48,13 +48,18 @@
             path = self;
           };
 
+          rustTargetSpec = buildPkgs.stdenv.hostPlatform.rust.rustcTargetSpec;
+          rustTargetSpecEnv = pkgs.lib.toUpper (builtins.replaceStrings [ "-" ] [ "_" ] rustTargetSpec);
+
+          isCross = buildPkgs.stdenv.hostPlatform != buildPkgs.stdenv.buildPlatform;
+
           commonArgs = {
             inherit src;
-            CARGO_BUILD_TARGET = buildPkgs.stdenv.hostPlatform.rust.rustcTarget;
-            "CC_${buildPkgs.stdenv.hostPlatform.rust.cargoEnvVarTarget}" =
-              "${buildPkgs.stdenv.cc.targetPrefix}cc";
-            "CARGO_TARGET_${buildPkgs.stdenv.hostPlatform.rust.cargoEnvVarTarget}_LINKER" =
-              "${buildPkgs.stdenv.cc.targetPrefix}cc";
+          }
+          // pkgs.lib.optionalAttrs isCross {
+            CARGO_BUILD_TARGET = rustTargetSpec;
+            "CC_${rustTargetSpecEnv}" = "${buildPkgs.stdenv.cc.targetPrefix}cc";
+            "CARGO_TARGET_${rustTargetSpecEnv}_LINKER" = "${buildPkgs.stdenv.cc.targetPrefix}cc";
           }
           // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
             CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";

--- a/flake.nix
+++ b/flake.nix
@@ -2,11 +2,6 @@
   inputs = {
     nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1";
 
-    fenix = {
-      url = "https://flakehub.com/f/nix-community/fenix/0";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
     crane.url = "https://flakehub.com/f/ipetkov/crane/0.20.3";
 
     easy-template = {
@@ -33,78 +28,50 @@
           system:
           f rec {
             inherit system;
-            pkgs = import inputs.nixpkgs {
-              inherit system;
-              overlays = [ self.overlays.default ];
-            };
+            pkgs = import inputs.nixpkgs { inherit system; };
           }
         );
 
       forAllSystems = forSystems supportedSystems;
     in
     {
-      overlays.default =
-        final: prev:
-        let
-          inherit (final.stdenv.hostPlatform) system;
-
-          rustToolchain =
-            with inputs.fenix.packages.${system};
-            combine (
-              [
-                stable.clippy
-                stable.rustc
-                stable.cargo
-                stable.rustfmt
-                stable.rust-src
-              ]
-              ++ inputs.nixpkgs.lib.optionals (system == "x86_64-linux") [
-                targets.x86_64-unknown-linux-musl.stable.rust-std
-              ]
-              ++ inputs.nixpkgs.lib.optionals (system == "aarch64-linux") [
-                targets.aarch64-unknown-linux-musl.stable.rust-std
-              ]
-            );
-
-          craneLib = (inputs.crane.mkLib final).overrideToolchain rustToolchain;
-        in
-        {
-          inherit rustToolchain craneLib;
-        };
-
       packages = forAllSystems (
         { pkgs, system }:
+        let
+          # pkgsStatic gives musl on Linux and statically-linked C libs on macOS
+          buildPkgs = pkgs.pkgsStatic;
+
+          craneLib = inputs.crane.mkLib buildPkgs;
+
+          src = builtins.path {
+            name = "flake-checker-src";
+            path = self;
+          };
+
+          commonArgs = {
+            inherit src;
+            depsBuildBuild = [ buildPkgs.stdenv.cc ];
+            CARGO_BUILD_TARGET = buildPkgs.stdenv.hostPlatform.rust.rustcTarget;
+            "CC_${buildPkgs.stdenv.hostPlatform.rust.cargoEnvVarTarget}" =
+              "${buildPkgs.stdenv.cc.targetPrefix}cc";
+            "CARGO_TARGET_${buildPkgs.stdenv.hostPlatform.rust.cargoEnvVarTarget}_LINKER" =
+              "${buildPkgs.stdenv.cc.targetPrefix}cc";
+          }
+          // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+            CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
+          };
+
+          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+        in
         rec {
           default = flake-checker;
-
-          flake-checker =
-            let
-              src = builtins.path {
-                name = "flake-checker-src";
-                path = self;
-              };
-              commonArgs = {
-                inherit src;
-              }
-              // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
-                CARGO_BUILD_TARGET =
-                  if system == "x86_64-linux" then
-                    "x86_64-unknown-linux-musl"
-                  else if system == "aarch64-linux" then
-                    "aarch64-unknown-linux-musl"
-                  else
-                    throw "Unsupported Linux system: ${system}";
-                CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
-              };
-              cargoArtifacts = pkgs.craneLib.buildDepsOnly commonArgs;
-            in
-            pkgs.craneLib.buildPackage (
-              commonArgs
-              // {
-                inherit cargoArtifacts;
-                doCheck = true;
-              }
-            );
+          flake-checker = craneLib.buildPackage (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
+              doCheck = true;
+            }
+          );
         }
       );
 
@@ -125,12 +92,18 @@
               };
               check-rust-fmt = pkgs.writeShellApplication {
                 name = "check-rust-fmt";
-                runtimeInputs = with pkgs; [ rustToolchain ];
+                runtimeInputs = with pkgs; [
+                  cargo
+                  rustfmt
+                ];
                 text = "cargo fmt --check";
               };
               get-ref-statuses = pkgs.writeShellApplication {
                 name = "get-ref-statuses";
-                runtimeInputs = with pkgs; [ rustToolchain ];
+                runtimeInputs = with pkgs; [
+                  cargo
+                  rustc
+                ];
                 text = "cargo run --features ref-statuses -- --get-ref-statuses";
               };
               update-readme = pkgs.writeShellApplication {
@@ -155,7 +128,10 @@
                 bashInteractive
 
                 # Rust
-                rustToolchain
+                rustc
+                cargo
+                clippy
+                rustfmt
                 cargo-bloat
                 cargo-edit
                 cargo-machete
@@ -175,7 +151,7 @@
 
               env = {
                 # Required by rust-analyzer
-                RUST_SRC_PATH = "${pkgs.rustToolchain}/lib/rustlib/src/rust/library";
+                RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
               };
             };
         }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,12 @@
   inputs = {
     nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1";
 
-    crane.url = "https://flakehub.com/f/ipetkov/crane/0.20.3";
+    fenix = {
+      url = "https://flakehub.com/f/nix-community/fenix/0.1";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    crane.url = "https://flakehub.com/f/ipetkov/crane/0";
 
     easy-template = {
       url = "https://flakehub.com/f/DeterminateSystems/easy-template/0";
@@ -13,8 +18,12 @@
   outputs =
     { self, ... }@inputs:
     let
+      inherit (inputs.nixpkgs) lib;
+
       lastModifiedDate = self.lastModifiedDate or self.lastModified or "19700101";
       version = "${builtins.substring 0 8 lastModifiedDate}-${self.shortRev or "dirty"}";
+
+      meta = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package;
 
       supportedSystems = [
         "x86_64-linux"
@@ -22,60 +31,25 @@
         "aarch64-darwin"
       ];
 
-      forSystems =
-        s: f:
-        inputs.nixpkgs.lib.genAttrs s (
+      forAllSystems =
+        f:
+        lib.genAttrs supportedSystems (
           system:
-          f rec {
+          f {
             inherit system;
-            pkgs = import inputs.nixpkgs { inherit system; };
+            pkgs = import inputs.nixpkgs {
+              inherit system;
+              overlays = [ self.overlays.default ];
+            };
           }
         );
-
-      forAllSystems = forSystems supportedSystems;
     in
     {
       packages = forAllSystems (
         { pkgs, system }:
-        let
-          # pkgsStatic gives musl on Linux and statically-linked C libs on macOS
-          buildPkgs = pkgs.pkgsStatic;
-
-          craneLib = inputs.crane.mkLib buildPkgs;
-
-          src = builtins.path {
-            name = "flake-checker-src";
-            path = self;
-          };
-
-          rustTargetSpec = buildPkgs.stdenv.hostPlatform.rust.rustcTargetSpec;
-          rustTargetSpecEnv = pkgs.lib.toUpper (builtins.replaceStrings [ "-" ] [ "_" ] rustTargetSpec);
-
-          isCross = buildPkgs.stdenv.hostPlatform != buildPkgs.stdenv.buildPlatform;
-
-          commonArgs = {
-            inherit src;
-          }
-          // pkgs.lib.optionalAttrs isCross {
-            CARGO_BUILD_TARGET = rustTargetSpec;
-            "CC_${rustTargetSpecEnv}" = "${buildPkgs.stdenv.cc.targetPrefix}cc";
-            "CARGO_TARGET_${rustTargetSpecEnv}_LINKER" = "${buildPkgs.stdenv.cc.targetPrefix}cc";
-          }
-          // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
-            CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
-          };
-
-          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
-        in
-        rec {
-          default = flake-checker;
-          flake-checker = craneLib.buildPackage (
-            commonArgs
-            // {
-              inherit cargoArtifacts;
-              doCheck = true;
-            }
-          );
+        {
+          default = self.packages.${system}.flake-checker;
+          inherit (pkgs) flake-checker;
         }
       );
 
@@ -88,7 +62,7 @@
                 name = "check-nix-fmt";
                 runtimeInputs = with pkgs; [
                   git
-                  nixfmt-rfc-style
+                  nixfmt
                 ];
                 text = ''
                   git ls-files '*.nix' | xargs nixfmt --check
@@ -97,16 +71,14 @@
               check-rust-fmt = pkgs.writeShellApplication {
                 name = "check-rust-fmt";
                 runtimeInputs = with pkgs; [
-                  cargo
-                  rustfmt
+                  rustToolchain
                 ];
                 text = "cargo fmt --check";
               };
               get-ref-statuses = pkgs.writeShellApplication {
                 name = "get-ref-statuses";
                 runtimeInputs = with pkgs; [
-                  cargo
-                  rustc
+                  rustToolchain
                 ];
                 text = "cargo run --features ref-statuses -- --get-ref-statuses";
               };
@@ -132,15 +104,11 @@
                 bashInteractive
 
                 # Rust
-                rustc
-                cargo
-                clippy
-                rustfmt
+                rustToolchain
                 cargo-bloat
                 cargo-edit
                 cargo-machete
                 cargo-watch
-                rust-analyzer
 
                 # CI checks
                 check-nix-fmt
@@ -153,14 +121,58 @@
                 self.formatter.${system}
               ];
 
-              env = {
-                # Required by rust-analyzer
-                RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
-              };
+              # Required by rust-analyzer
+              env.RUST_SRC_PATH = "${pkgs.rustToolchain}/lib/rustlib/src/rust/library";
             };
         }
       );
 
-      formatter = forAllSystems ({ pkgs, ... }: pkgs.nixfmt-rfc-style);
+      formatter = forAllSystems ({ pkgs, ... }: pkgs.nixfmt);
+
+      overlays.default =
+        final: prev:
+        let
+          meta = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package;
+
+          inherit (prev.stdenv.hostPlatform) system;
+
+          staticTarget =
+            {
+              "aarch64-linux" = "aarch64-unknown-linux-musl";
+              "x86_64-linux" = "x86_64-unknown-linux-musl";
+            }
+            .${system} or null;
+
+          rustToolchain =
+            with inputs.fenix.packages.${system};
+            combine (
+              with stable;
+              [
+                clippy
+                rustc
+                cargo
+                rustfmt
+                rust-src
+                rust-analyzer
+              ]
+              ++ lib.optionals (staticTarget != null) [
+                targets.${staticTarget}.stable.rust-std
+              ]
+            );
+
+          craneLib = (inputs.crane.mkLib prev).overrideToolchain rustToolchain;
+        in
+        {
+          flake-checker = craneLib.buildPackage {
+            inherit (meta) name;
+            inherit version;
+            src = builtins.path {
+              name = "flake-checker-src";
+              path = self;
+            };
+          };
+
+          inherit rustToolchain;
+        };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "https://flakehub.com/f/DeterminateSystems/secure/0";
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1";
 
     fenix = {
       url = "https://flakehub.com/f/nix-community/fenix/0";

--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,6 @@
 
           commonArgs = {
             inherit src;
-            depsBuildBuild = [ buildPkgs.stdenv.cc ];
             CARGO_BUILD_TARGET = buildPkgs.stdenv.hostPlatform.rust.rustcTarget;
             "CC_${buildPkgs.stdenv.hostPlatform.rust.cargoEnvVarTarget}" =
               "${buildPkgs.stdenv.cc.targetPrefix}cc";

--- a/flake.nix
+++ b/flake.nix
@@ -163,17 +163,39 @@
           craneLib = (inputs.crane.mkLib prev).overrideToolchain rustToolchain;
         in
         {
-          flake-checker = craneLib.buildPackage {
-            inherit (meta) name;
-            inherit version;
-            src = builtins.path {
-              name = "flake-checker-src";
-              path = self;
-            };
-            env = lib.optionalAttrs (staticTarget != null) {
-              CARGO_BUILD_TARGET = staticTarget;
-            };
-          };
+          flake-checker =
+            let
+              sharedAttrs = {
+                inherit (meta) name;
+                inherit version;
+
+                src = builtins.path {
+                  name = "flake-checker-src";
+                  path = self;
+                };
+
+                env = lib.optionalAttrs (staticTarget != null) {
+                  CARGO_BUILD_TARGET = staticTarget;
+                };
+              };
+            in
+            craneLib.buildPackage (
+              sharedAttrs
+              // {
+                cargoArtifacts = craneLib.buildDepsOnly sharedAttrs;
+
+                disallowedReferences = lib.optionals final.stdenv.hostPlatform.isDarwin [
+                  final.libiconv
+                ];
+
+                postFixup = lib.optionalString final.stdenv.hostPlatform.isDarwin ''
+                  install_name_tool -change \
+                    "$(otool -L $out/bin/flake-checker | grep libiconv | awk '{print $1}')" \
+                    /usr/lib/libiconv.2.dylib \
+                    $out/bin/flake-checker
+                '';
+              }
+            );
 
           inherit rustToolchain;
         };

--- a/flake.nix
+++ b/flake.nix
@@ -170,6 +170,9 @@
               name = "flake-checker-src";
               path = self;
             };
+            env = lib.optionalAttrs (staticTarget != null) {
+              CARGO_BUILD_TARGET = staticTarget;
+            };
           };
 
           inherit rustToolchain;

--- a/flake.nix
+++ b/flake.nix
@@ -7,10 +7,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    naersk = {
-      url = "https://flakehub.com/f/nix-community/naersk/0";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "https://flakehub.com/f/ipetkov/crane/0.20.3";
 
     easy-template = {
       url = "https://flakehub.com/f/DeterminateSystems/easy-template/0";
@@ -68,14 +65,11 @@
                 targets.aarch64-unknown-linux-musl.stable.rust-std
               ]
             );
+
+          craneLib = (inputs.crane.mkLib final).overrideToolchain rustToolchain;
         in
         {
-          inherit rustToolchain;
-
-          naerskLib = final.callPackage inputs.naersk {
-            cargo = rustToolchain;
-            rustc = rustToolchain;
-          };
+          inherit rustToolchain craneLib;
         };
 
       packages = forAllSystems (
@@ -83,27 +77,34 @@
         rec {
           default = flake-checker;
 
-          flake-checker = pkgs.naerskLib.buildPackage (
-            {
-              name = "flake-checker";
+          flake-checker =
+            let
               src = builtins.path {
                 name = "flake-checker-src";
                 path = self;
               };
-              doCheck = true;
-              nativeBuildInputs = with pkgs; [ ] ++ lib.optionals stdenv.isDarwin [ libiconv ];
-            }
-            // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
-              CARGO_BUILD_TARGET =
-                if system == "x86_64-linux" then
-                  "x86_64-unknown-linux-musl"
-                else if system == "aarch64-linux" then
-                  "aarch64-unknown-linux-musl"
-                else
-                  throw "Unsupported Linux system: ${system}";
-              CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
-            }
-          );
+              commonArgs = {
+                inherit src;
+              }
+              // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+                CARGO_BUILD_TARGET =
+                  if system == "x86_64-linux" then
+                    "x86_64-unknown-linux-musl"
+                  else if system == "aarch64-linux" then
+                    "aarch64-unknown-linux-musl"
+                  else
+                    throw "Unsupported Linux system: ${system}";
+                CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
+              };
+              cargoArtifacts = pkgs.craneLib.buildDepsOnly commonArgs;
+            in
+            pkgs.craneLib.buildPackage (
+              commonArgs
+              // {
+                inherit cargoArtifacts;
+                doCheck = true;
+              }
+            );
         }
       );
 

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,15 @@
             };
           }
         );
+
+      staticTarget' =
+        system:
+        {
+          "aarch64-linux" = "aarch64-unknown-linux-musl";
+          "x86_64-linux" = "x86_64-unknown-linux-musl";
+        }
+        .${system} or null;
+
     in
     {
       packages = forAllSystems (
@@ -58,6 +67,9 @@
         {
           default =
             let
+              staticTarget = staticTarget' system;
+              pkgs' = if staticTarget != null then pkgs.pkgsStatic else pkgs;
+
               check-nix-fmt = pkgs.writeShellApplication {
                 name = "check-nix-fmt";
                 runtimeInputs = with pkgs; [
@@ -99,11 +111,12 @@
                 '';
               };
             in
-            pkgs.mkShell {
+            pkgs'.mkShell {
               packages = with pkgs; [
                 bashInteractive
 
                 # Rust
+                lld
                 rustToolchain
                 cargo-bloat
                 cargo-edit
@@ -122,7 +135,10 @@
               ];
 
               # Required by rust-analyzer
-              env.RUST_SRC_PATH = "${pkgs.rustToolchain}/lib/rustlib/src/rust/library";
+              env = {
+                RUST_SRC_PATH = "${pkgs.rustToolchain}/lib/rustlib/src/rust/library";
+              }
+              // pkgs.env;
             };
         }
       );
@@ -136,12 +152,8 @@
 
           inherit (prev.stdenv.hostPlatform) system;
 
-          staticTarget =
-            {
-              "aarch64-linux" = "aarch64-unknown-linux-musl";
-              "x86_64-linux" = "x86_64-unknown-linux-musl";
-            }
-            .${system} or null;
+          staticTarget = staticTarget' system;
+          pkgs' = if staticTarget != null then final.pkgsStatic else final;
 
           rustToolchain =
             with inputs.fenix.packages.${system};
@@ -160,7 +172,15 @@
               ]
             );
 
-          craneLib = (inputs.crane.mkLib prev).overrideToolchain rustToolchain;
+          craneLib = (inputs.crane.mkLib pkgs').overrideToolchain (_: rustToolchain);
+
+          rustTargetSpec = final.stdenv.hostPlatform.rust.rustcTargetSpec;
+          rustTargetSpecEnv = lib.toUpper (builtins.replaceStrings [ "-" ] [ "_" ] rustTargetSpec);
+
+          env = lib.optionalAttrs (staticTarget != null) {
+            CARGO_BUILD_TARGET = staticTarget;
+            "CARGO_TARGET_${rustTargetSpecEnv}_LINKER" = "${final.stdenv.cc.targetPrefix}cc";
+          };
         in
         {
           flake-checker =
@@ -174,9 +194,14 @@
                   path = self;
                 };
 
-                env = lib.optionalAttrs (staticTarget != null) {
-                  CARGO_BUILD_TARGET = staticTarget;
-                };
+                depsBuildBuild = [
+                  pkgs'.buildPackages.stdenv.cc
+                  pkgs'.lld
+                ];
+
+                doIncludeCrossToolchainEnv = false;
+
+                inherit env;
               };
             in
             craneLib.buildPackage (
@@ -197,7 +222,7 @@
               }
             );
 
-          inherit rustToolchain;
+          inherit env rustToolchain;
         };
     };
 }

--- a/templates/README.md.handlebars
+++ b/templates/README.md.handlebars
@@ -93,7 +93,7 @@ You can automate Nix Flake Checker by adding Determinate Systems' [Nix Flake Che
 ```yaml
 checks:
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Check Nix flake Nixpkgs inputs
       uses: DeterminateSystems/flake-checker-action@main
 ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched project base to NixOS nixpkgs v0.1, upgraded fenix, and replaced the previous Rust build helper with a new build tool.
  * Updated formatter and development shell packages and tooling; adjusted build targets for Linux-musl.

* **New Features**
  * Builds now produce/verify statically-linked Linux artifacts when applicable.
  * Updated HTTP client dependency to a newer release.

* **Documentation**
  * Updated README and workflow examples to reflect CI changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->