### PR TITLE
Update permissions in update-flake-lock.yaml

### DIFF
--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -9,8 +9,10 @@ jobs:
   lockfile:
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       id-token: write
-      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/determinate-nix-action@main


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to grant broader write access, enabling automated repository updates and the creation/updating of related issues and pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->