### PR TITLE
Update Nixpkgs ref statuses for 26.05

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,10 @@ jobs:
         run: nix develop -c check-rust-fmt
       - name: Clippy
         run: nix develop -c cargo clippy
+      - name: Check generated README up to date
+        run: |
+          nix develop -c update-readme
+          git diff --exit-code
 
   rust-tests:
     name: Test Rust

--- a/.github/workflows/ref-statuses.yaml
+++ b/.github/workflows/ref-statuses.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Create pull request
         if: failure()
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: Update ref-statuses.json to new valid Git refs list and update README
           title: Update ref-statuses.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,7 +512,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flake-checker"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "cel",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flake-checker"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2024"
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can apply a CEL condition to your flake using the `--condition` flag.
 Here's an example:
 
 ```shell
-flake-checker --condition "has(numDaysOld) && numDaysOld < 365"
+flake-checker --condition "numDaysOld < 365"
 ```
 
 This would check that each Nixpkgs input in your `flake.lock` is less than 365 days old.
@@ -80,7 +80,7 @@ These variables are available in each condition:
 We recommend a condition _at least_ this stringent:
 
 ```ruby
-supportedRefs.contains(gitRef) && (has(numDaysOld) && numDaysOld < 30) && owner == 'NixOS'
+supportedRefs.contains(gitRef) && numDaysOld < 30 && owner == 'NixOS'
 ```
 
 Note that not all Nixpkgs inputs have a `numDaysOld` field, so make sure to ensure that that field exists when checking for the number of days.
@@ -89,7 +89,7 @@ Here are some other example conditions:
 
 ```ruby
 # Updated in the last two weeks
-supportedRefs.contains(gitRef) && (has(numDaysOld) && numDaysOld < 14) && owner == 'NixOS'
+supportedRefs.contains(gitRef) && numDaysOld < 14 && owner == 'NixOS'
 
 # Check for most recent stable Nixpkgs
 gitRef.contains("24.05")

--- a/README.md
+++ b/README.md
@@ -32,10 +32,13 @@ The current list, with their statuses:
 - `nixos-25.05-small`
 - `nixos-25.11`
 - `nixos-25.11-small`
+- `nixos-26.05`
+- `nixos-26.05-small`
 - `nixos-unstable`
 - `nixos-unstable-small`
 - `nixpkgs-25.05-darwin`
 - `nixpkgs-25.11-darwin`
+- `nixpkgs-26.05-darwin`
 - `nixpkgs-unstable`
 
 ## Parameters
@@ -60,7 +63,7 @@ You can apply a CEL condition to your flake using the `--condition` flag.
 Here's an example:
 
 ```shell
-flake-checker --condition "numDaysOld < 365"
+flake-checker --condition "has(numDaysOld) && numDaysOld < 365"
 ```
 
 This would check that each Nixpkgs input in your `flake.lock` is less than 365 days old.
@@ -77,16 +80,16 @@ These variables are available in each condition:
 We recommend a condition _at least_ this stringent:
 
 ```ruby
-supportedRefs.contains(gitRef) && numDaysOld < 30 && owner == 'NixOS'
+supportedRefs.contains(gitRef) && (has(numDaysOld) && numDaysOld < 30) && owner == 'NixOS'
 ```
 
-Inputs without a `numDaysOld` (e.g. those never locked with a timestamp) default to `0`, which means a bare `numDaysOld < N` check silently passes them. Add `numDaysOld > 0 &&` to your condition if you want to require the field be set.
+Note that not all Nixpkgs inputs have a `numDaysOld` field, so make sure to ensure that that field exists when checking for the number of days.
 
 Here are some other example conditions:
 
 ```ruby
 # Updated in the last two weeks
-supportedRefs.contains(gitRef) && numDaysOld < 14 && owner == 'NixOS'
+supportedRefs.contains(gitRef) && (has(numDaysOld) && numDaysOld < 14) && owner == 'NixOS'
 
 # Check for most recent stable Nixpkgs
 gitRef.contains("24.05")
@@ -162,3 +165,4 @@ If you'd like to help make the parser more exhaustive, [pull requests][prs] are 
 [rust]: https://rust-lang.org
 [telemetry]: https://github.com/DeterminateSystems/nix-flake-checker/blob/main/src/telemetry.rs#L29-L43
 [val]: https://docs.rs/serde_json/latest/serde_json/value/enum.Value.html
+

--- a/ref-statuses.json
+++ b/ref-statuses.json
@@ -3,9 +3,12 @@
   "nixos-25.05-small": "unmaintained",
   "nixos-25.11": "stable",
   "nixos-25.11-small": "stable",
+  "nixos-26.05": "beta",
+  "nixos-26.05-small": "beta",
   "nixos-unstable": "rolling",
   "nixos-unstable-small": "rolling",
   "nixpkgs-25.05-darwin": "unmaintained",
   "nixpkgs-25.11-darwin": "stable",
+  "nixpkgs-26.05-darwin": "beta",
   "nixpkgs-unstable": "rolling"
 }

--- a/templates/README.md.handlebars
+++ b/templates/README.md.handlebars
@@ -54,7 +54,7 @@ You can apply a CEL condition to your flake using the `--condition` flag.
 Here's an example:
 
 ```shell
-flake-checker --condition "has(numDaysOld) && numDaysOld < 365"
+flake-checker --condition "numDaysOld < 365"
 ```
 
 This would check that each Nixpkgs input in your `flake.lock` is less than 365 days old.
@@ -71,7 +71,7 @@ These variables are available in each condition:
 We recommend a condition _at least_ this stringent:
 
 ```ruby
-supportedRefs.contains(gitRef) && (has(numDaysOld) && numDaysOld < 30) && owner == 'NixOS'
+supportedRefs.contains(gitRef) && numDaysOld < 30 && owner == 'NixOS'
 ```
 
 Note that not all Nixpkgs inputs have a `numDaysOld` field, so make sure to ensure that that field exists when checking for the number of days.
@@ -80,7 +80,7 @@ Here are some other example conditions:
 
 ```ruby
 # Updated in the last two weeks
-supportedRefs.contains(gitRef) && (has(numDaysOld) && numDaysOld < 14) && owner == 'NixOS'
+supportedRefs.contains(gitRef) && numDaysOld < 14 && owner == 'NixOS'
 
 # Check for most recent stable Nixpkgs
 gitRef.contains("24.05")


### PR DESCRIPTION
I'm not sure why the automated PR logic isn't working, but this PR serves as a replacement for that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.2.12.
  * Marked additional 26.05-series references as beta, including small-environment and Darwin variants.
  * CI now regenerates the README during checks and fails if unexpected changes appear.
  * Updated pull-request creation tooling to a newer version.

* **Documentation**
  * Clarified supported-branch list and guidance for handling numDaysOld (may be absent); refreshed example policy expressions and minor formatting fixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeterminateSystems/flake-checker/pull/230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->