### PR TITLE
Recognize Determinate Secure Packages as supported Nixpkgs inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,7 +512,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flake-checker"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "cel",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flake-checker"
-version = "0.2.14"
+version = "0.2.15"
 edition = "2024"
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ The current list, with their statuses:
 - `nixpkgs-26.05-darwin`
 - `nixpkgs-unstable`
 
+## Determinate Secure Packages
+
+[Determinate Secure Packages][secure-packages] flakes count as supported Nixpkgs inputs, so Flake Checker doesn't flag them for using an unsupported Git ref or a non-upstream owner:
+
+```nix
+{
+  inputs.nixpkgs.url = "https://flakehub.com/f/DeterminateSystems/secure-packages-rolling/*";
+}
+```
+
+Any [FlakeHub] flake published under the `DeterminateSystems` org with a name starting with `secure-packages` qualifies, such as `secure-packages-rolling`, `secure-packages-26.05`, and `secure-packages-26.05-fips`.
+
+The age check still applies, because Secure Packages flakes receive a continuous stream of security updates that you should be picking up.
+
 ## Parameters
 
 By default, Flake Checker verifies that:
@@ -45,6 +59,8 @@ By default, Flake Checker verifies that:
 - Any explicit Nixpkgs Git refs are in the [supported list](#supported-branches).
 - Any Nixpkgs dependencies are less than 30 days old.
 - Any Nixpkgs dependencies have the [`NixOS`][nixos-org] org as the GitHub owner (and thus that the dependency isn't a fork or non-upstream variant).
+
+[Determinate Secure Packages](#determinate-secure-packages) inputs are exempt from the ref and owner checks.
 
 You can adjust this behavior via configuration (all are enabled by default but you can disable them):
 
@@ -150,6 +166,7 @@ If you'd like to help make the parser more exhaustive, [pull requests][prs] are 
 [action]: https://github.com/DeterminateSystems/flake-checker-action
 [cel]: https://cel.dev
 [detsys]: https://determinate.systems
+[flakehub]: https://flakehub.com
 [flakes]: https://zero-to-nix.com/concepts/flakes
 [install]: https://zero-to-nix.com/start/install
 [installer]: https://github.com/DeterminateSystems/nix-installer
@@ -160,6 +177,7 @@ If you'd like to help make the parser more exhaustive, [pull requests][prs] are 
 [privacy]: https://determinate.systems/policies/privacy
 [prs]: /pulls
 [rust]: https://rust-lang.org
+[secure-packages]: https://docs.determinate.systems/secure-packages
 [telemetry]: https://github.com/DeterminateSystems/nix-flake-checker/blob/main/src/telemetry.rs#L29-L43
 [val]: https://docs.rs/serde_json/latest/serde_json/value/enum.Value.html
 

--- a/README.md
+++ b/README.md
@@ -38,20 +38,6 @@ The current list, with their statuses:
 - `nixpkgs-26.05-darwin`
 - `nixpkgs-unstable`
 
-## Determinate Secure Packages
-
-[Determinate Secure Packages][secure-packages] flakes count as supported Nixpkgs inputs, so Flake Checker doesn't flag them for using an unsupported Git ref or a non-upstream owner:
-
-```nix
-{
-  inputs.nixpkgs.url = "https://flakehub.com/f/DeterminateSystems/secure-packages-rolling/*";
-}
-```
-
-Any [FlakeHub] flake published under the `DeterminateSystems` org with a name starting with `secure-packages` qualifies, such as `secure-packages-rolling`, `secure-packages-26.05`, and `secure-packages-26.05-fips`.
-
-The age check still applies, because Secure Packages flakes receive a continuous stream of security updates that you should be picking up.
-
 ## Parameters
 
 By default, Flake Checker verifies that:
@@ -59,8 +45,6 @@ By default, Flake Checker verifies that:
 - Any explicit Nixpkgs Git refs are in the [supported list](#supported-branches).
 - Any Nixpkgs dependencies are less than 30 days old.
 - Any Nixpkgs dependencies have the [`NixOS`][nixos-org] org as the GitHub owner (and thus that the dependency isn't a fork or non-upstream variant).
-
-[Determinate Secure Packages](#determinate-secure-packages) inputs are exempt from the ref and owner checks.
 
 You can adjust this behavior via configuration (all are enabled by default but you can disable them):
 
@@ -166,7 +150,6 @@ If you'd like to help make the parser more exhaustive, [pull requests][prs] are 
 [action]: https://github.com/DeterminateSystems/flake-checker-action
 [cel]: https://cel.dev
 [detsys]: https://determinate.systems
-[flakehub]: https://flakehub.com
 [flakes]: https://zero-to-nix.com/concepts/flakes
 [install]: https://zero-to-nix.com/start/install
 [installer]: https://github.com/DeterminateSystems/nix-installer
@@ -177,7 +160,6 @@ If you'd like to help make the parser more exhaustive, [pull requests][prs] are 
 [privacy]: https://determinate.systems/policies/privacy
 [prs]: /pulls
 [rust]: https://rust-lang.org
-[secure-packages]: https://docs.determinate.systems/secure-packages
 [telemetry]: https://github.com/DeterminateSystems/nix-flake-checker/blob/main/src/telemetry.rs#L29-L43
 [val]: https://docs.rs/serde_json/latest/serde_json/value/enum.Value.html
 

--- a/src/flake.rs
+++ b/src/flake.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 
 use crate::FlakeCheckerError;
 use crate::issue::{Disallowed, Issue, IssueKind, NonUpstream, Outdated};
+use crate::secure_packages::is_secure_packages_url;
 
 use chrono::{Duration, Utc};
 use parse_flake_lock::{FlakeLock, Node};
@@ -86,20 +87,26 @@ pub(crate) fn check_flake_lock(
     let deps = nixpkgs_deps(flake_lock, &config.nixpkgs_keys)?;
 
     for (name, node) in deps {
-        let (git_ref, last_modified, owner) = match node {
+        let (git_ref, last_modified, owner, secure_packages) = match node {
             Node::Repo(repo) => (
                 repo.original.git_ref,
                 Some(repo.locked.last_modified),
                 Some(repo.original.owner),
+                false,
             ),
-            Node::Tarball(tarball) => (None, tarball.locked.last_modified, None),
-            _ => (None, None, None),
+            Node::Tarball(tarball) => {
+                let secure_packages = is_secure_packages_url(&tarball.original.url)
+                    || is_secure_packages_url(&tarball.locked.url);
+
+                (None, tarball.locked.last_modified, None, secure_packages)
+            }
+            _ => (None, None, None, false),
         };
 
-        // Check if not explicitly supported
+        // Secure Packages flakes are exempt from the ref and owner checks, but not the age check
         if let Some(git_ref) = git_ref {
             // Check if not explicitly supported
-            if config.check_supported && !allowed_refs.contains(&git_ref) {
+            if config.check_supported && !secure_packages && !allowed_refs.contains(&git_ref) {
                 issues.push(Issue {
                     input: name.clone(),
                     kind: IssueKind::Disallowed(Disallowed {
@@ -125,7 +132,7 @@ pub(crate) fn check_flake_lock(
 
         if let Some(owner) = owner {
             // Check that the GitHub owner is NixOS
-            if config.check_owner && owner.to_lowercase() != "nixos" {
+            if config.check_owner && !secure_packages && owner.to_lowercase() != "nixos" {
                 issues.push(Issue {
                     input: name.clone(),
                     kind: IssueKind::NonUpstream(NonUpstream { owner }),
@@ -199,7 +206,7 @@ mod test {
         let ref_statuses: BTreeMap<String, String> =
             serde_json::from_str(include_str!("../ref-statuses.json")).unwrap();
         let allowed_refs = supported_refs(ref_statuses);
-        for n in 0..=7 {
+        for n in 0..=8 {
             let path = PathBuf::from(format!("tests/flake.clean.{n}.lock"));
             let flake_lock = FlakeLock::new(&path).unwrap();
             let config = FlakeCheckConfig {
@@ -251,6 +258,24 @@ mod test {
                         input: String::from("nixpkgs"),
                         kind: IssueKind::NonUpstream(NonUpstream {
                             owner: String::from("pretty-shady"),
+                        }),
+                    },
+                ],
+            ),
+            // Secure Packages is a FlakeHub-only product, so the GitHub form gets no exemption
+            (
+                "flake.dirty.2.lock",
+                vec![
+                    Issue {
+                        input: String::from("nixpkgs"),
+                        kind: IssueKind::Disallowed(Disallowed {
+                            reference: String::from("main"),
+                        }),
+                    },
+                    Issue {
+                        input: String::from("nixpkgs"),
+                        kind: IssueKind::NonUpstream(NonUpstream {
+                            owner: String::from("DeterminateSystems"),
                         }),
                     },
                 ],

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod condition;
 mod error;
 mod flake;
 mod issue;
+mod secure_packages;
 mod summary;
 
 #[cfg(feature = "ref-statuses")]

--- a/src/secure_packages.rs
+++ b/src/secure_packages.rs
@@ -2,7 +2,8 @@
 //!
 //! These flakes are available only from FlakeHub, published under the `DeterminateSystems` org
 //! with names beginning with `secure-packages` (`secure-packages-rolling`,
-//! `secure-packages-26.05`, `secure-packages-rolling-fips`, and so on).
+//! `secure-packages-26.05`, `secure-packages-rolling-fips`, `secure-packages-26.05-fips`, and so
+//! on).
 
 const DETERMINATE_ORG: &str = "determinatesystems";
 const SECURE_PACKAGES_PREFIX: &str = "secure-packages";
@@ -62,6 +63,7 @@ mod test {
             ("DeterminateSystems", "secure-packages-rolling-fips", true),
             ("DeterminateSystems", "secure-packages-25.11", true),
             ("DeterminateSystems", "secure-packages-26.05", true),
+            ("DeterminateSystems", "secure-packages-26.05-fips", true),
             // Channels that don't exist yet still match the prefix
             ("DeterminateSystems", "secure-packages-26.11", true),
             ("DeterminateSystems", "secure-packages", true),

--- a/src/secure_packages.rs
+++ b/src/secure_packages.rs
@@ -2,7 +2,7 @@
 //!
 //! These flakes are available only from FlakeHub, published under the `DeterminateSystems` org
 //! with names beginning with `secure-packages` (`secure-packages-rolling`,
-//! `secure-packages-26.05-fips`, and so on).
+//! `secure-packages-26.05`, `secure-packages-rolling-fips`, and so on).
 
 const DETERMINATE_ORG: &str = "determinatesystems";
 const SECURE_PACKAGES_PREFIX: &str = "secure-packages";
@@ -62,7 +62,6 @@ mod test {
             ("DeterminateSystems", "secure-packages-rolling-fips", true),
             ("DeterminateSystems", "secure-packages-25.11", true),
             ("DeterminateSystems", "secure-packages-26.05", true),
-            ("DeterminateSystems", "secure-packages-26.05-fips", true),
             // Channels that don't exist yet still match the prefix
             ("DeterminateSystems", "secure-packages-26.11", true),
             ("DeterminateSystems", "secure-packages", true),

--- a/src/secure_packages.rs
+++ b/src/secure_packages.rs
@@ -1,0 +1,128 @@
+//! Recognition of Determinate Secure Packages flakes as legitimate Nixpkgs inputs.
+//!
+//! These flakes are available only from FlakeHub, published under the `DeterminateSystems` org
+//! with names beginning with `secure-packages` (`secure-packages-rolling`,
+//! `secure-packages-26.05-fips`, and so on).
+
+const DETERMINATE_ORG: &str = "determinatesystems";
+const SECURE_PACKAGES_PREFIX: &str = "secure-packages";
+const FLAKEHUB_HOSTS: &[&str] = &["flakehub.com", "api.flakehub.com"];
+
+/// Whether a tarball URL points to a Determinate Secure Packages flake on FlakeHub. Handles both
+/// the user-supplied form (`https://flakehub.com/f/{org}/{name}/{version}`) and the locked form
+/// (`https://api.flakehub.com/f/pinned/{org}/{name}/{version}/{uuid}/source.tar.gz`).
+pub(crate) fn is_secure_packages_url(url: &str) -> bool {
+    let Some((_scheme, rest)) = url.split_once("://") else {
+        return false;
+    };
+
+    let mut segments = rest.split('/');
+
+    let Some(host) = segments.next() else {
+        return false;
+    };
+
+    if !FLAKEHUB_HOSTS.contains(&host.to_lowercase().as_str()) {
+        return false;
+    }
+
+    if segments.next() != Some("f") {
+        return false;
+    }
+
+    // Locked FlakeHub URLs insert a `pinned` segment before the org
+    let owner = match segments.next() {
+        Some("pinned") => segments.next(),
+        owner => owner,
+    };
+
+    let (Some(owner), Some(name)) = (owner, segments.next()) else {
+        return false;
+    };
+
+    is_secure_packages_flake(owner, name)
+}
+
+fn is_secure_packages_flake(owner: &str, name: &str) -> bool {
+    owner.to_lowercase() == DETERMINATE_ORG && is_secure_packages_name(&name.to_lowercase())
+}
+
+fn is_secure_packages_name(name: &str) -> bool {
+    name == SECURE_PACKAGES_PREFIX || name.starts_with(&format!("{SECURE_PACKAGES_PREFIX}-"))
+}
+
+#[cfg(test)]
+mod test {
+    use super::{is_secure_packages_flake, is_secure_packages_url};
+
+    #[test]
+    fn secure_packages_flakes() {
+        let cases: Vec<(&str, &str, bool)> = vec![
+            ("DeterminateSystems", "secure-packages-rolling", true),
+            ("DeterminateSystems", "secure-packages-rolling-fips", true),
+            ("DeterminateSystems", "secure-packages-25.11", true),
+            ("DeterminateSystems", "secure-packages-26.05", true),
+            ("DeterminateSystems", "secure-packages-26.05-fips", true),
+            // Channels that don't exist yet still match the prefix
+            ("DeterminateSystems", "secure-packages-26.11", true),
+            ("DeterminateSystems", "secure-packages", true),
+            ("determinatesystems", "secure-packages-rolling", true),
+            // Right name, wrong org
+            ("NotDeterminateSystems", "secure-packages-rolling", false),
+            ("someone-else", "secure-packages-rolling", false),
+            // Right org, wrong name
+            ("DeterminateSystems", "nixpkgs", false),
+            ("DeterminateSystems", "secure-packagesrolling", false),
+            ("DeterminateSystems", "not-secure-packages-rolling", false),
+        ];
+
+        for (owner, name, expected) in cases {
+            assert_eq!(
+                is_secure_packages_flake(owner, name),
+                expected,
+                "unexpected result for {owner}/{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn secure_packages_urls() {
+        let cases: Vec<(&str, bool)> = vec![
+            (
+                "https://flakehub.com/f/DeterminateSystems/secure-packages-rolling/*",
+                true,
+            ),
+            (
+                "https://flakehub.com/f/DeterminateSystems/secure-packages-26.05/0.1.tar.gz",
+                true,
+            ),
+            (
+                "https://api.flakehub.com/f/pinned/DeterminateSystems/secure-packages-rolling/0.1.1%2Brev-6fb441f657e98f31024f19ca68b691c5b0c3fdd6/01978415-c996-7747-a25c-77ca3a4c5ed9/source.tar.gz",
+                true,
+            ),
+            // Right flake, wrong host
+            (
+                "https://example.com/f/DeterminateSystems/secure-packages-rolling/*",
+                false,
+            ),
+            // Right host, wrong flake
+            ("https://flakehub.com/f/NixOS/nixpkgs/0.1", false),
+            (
+                "https://flakehub.com/f/DeterminateSystems/easy-template/0",
+                false,
+            ),
+            // Not a FlakeHub URL at all
+            ("https://some-server.com/flake.tar.gz", false),
+            ("flakehub.com/f/DeterminateSystems/secure-packages", false),
+            ("https://flakehub.com/f/DeterminateSystems", false),
+        ];
+
+        for (url, expected) in cases {
+            assert_eq!(
+                is_secure_packages_url(url),
+                expected,
+                "unexpected result for {url}"
+            );
+        }
+    }
+}

--- a/tests/flake.clean.8.lock
+++ b/tests/flake.clean.8.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779041105,
+        "narHash": "sha256-nnGD2f8OlAZT2i5OfwikJsw+ifWfiA4d6A8BWlgOXV0=",
+        "rev": "10e6e3cb966f7cfcc789fe5eee7a85f3188ce08b",
+        "revCount": 858,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/secure-packages-rolling/0.1.858%2Brev-10e6e3cb966f7cfcc789fe5eee7a85f3188ce08b/019e3726-d9ea-7820-aece-59009301cab1/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/DeterminateSystems/secure-packages-rolling/*"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/flake.dirty.2.lock
+++ b/tests/flake.dirty.2.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779041105,
+        "narHash": "sha256-nnGD2f8OlAZT2i5OfwikJsw+ifWfiA4d6A8BWlgOXV0=",
+        "owner": "DeterminateSystems",
+        "repo": "secure-packages-26.05-fips",
+        "rev": "10e6e3cb966f7cfcc789fe5eee7a85f3188ce08b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DeterminateSystems",
+        "ref": "main",
+        "repo": "secure-packages-26.05-fips",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/flake.dirty.2.lock
+++ b/tests/flake.dirty.2.lock
@@ -5,14 +5,14 @@
         "lastModified": 1779041105,
         "narHash": "sha256-nnGD2f8OlAZT2i5OfwikJsw+ifWfiA4d6A8BWlgOXV0=",
         "owner": "DeterminateSystems",
-        "repo": "secure-packages-26.05-fips",
+        "repo": "secure-packages-rolling-fips",
         "rev": "10e6e3cb966f7cfcc789fe5eee7a85f3188ce08b",
         "type": "github"
       },
       "original": {
         "owner": "DeterminateSystems",
         "ref": "main",
-        "repo": "secure-packages-26.05-fips",
+        "repo": "secure-packages-rolling-fips",
         "type": "github"
       }
     },


### PR DESCRIPTION
An issue that has recently emerged is that if you're using "Nixpkgs" as one of our [Determinate Secure Packages](https://determinate.systems/products/secure-packages) variants (`secure-packages-*`) then Flake Checker won't recognize those as Nixpkgs inputs. This PR updates FC's machinery to handle those.

## Testing

- `tests/flake.clean.8.lock` covers the FlakeHub form and is expected to be clean.
- `tests/flake.dirty.2.lock` pulls the same flake from GitHub and is still expected to produce both issues, since Secure Packages only comes from FlakeHub.
- Unit tests in `src/secure_packages.rs` cover the name matching and both URL forms, including near misses (right name/wrong org, right host/wrong flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing Determinate Secure Packages hosted on FlakeHub, including standard and pinned package URLs.
  * Secure Packages dependencies now bypass supported-reference and owner checks while continuing to receive outdated-version checks.
  * Added validation for supported hosts, owners, and package naming conventions.

* **Bug Fixes**
  * Improved handling of GitHub-form Secure Packages references in lockfiles.

* **Release**
  * Updated the package version to 0.2.15.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->